### PR TITLE
Implement auth checks from journald. Closes #12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,9 +17,10 @@ FROM python:3.7-slim-stretch
 WORKDIR /usr/src/app
 ENV PYTHONUNBUFFERED=1
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends build-essential libssl-dev libffi-dev libltdl-dev curl && \
-    apt-get clean
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends build-essential libssl-dev libffi-dev libltdl-dev \
+                                               curl pkg-config libsystemd-dev iptables nmap \
+ && apt-get clean
 
 COPY --from=build /go/src/github.com/square/ghostunnel/ghostunnel /usr/local/bin/
 

--- a/agent/checks/auth.py
+++ b/agent/checks/auth.py
@@ -1,0 +1,70 @@
+import time
+import enum
+import typing
+import collections
+
+import systemd.journal
+
+SYSLOG_AUTHPRIV = 10
+
+
+def check(timespan=60 * 60):
+    """
+    Generator that yields AUTHPRIV messages from journald
+    for the specified time span.
+
+    :param timespan: Yield records only for this time span.
+        Default is 1 hour.
+    """
+    journal = systemd.journal.Reader()
+    journal.log_level(systemd.journal.LOG_INFO)
+    journal.add_match(SYSLOG_FACILITY=SYSLOG_AUTHPRIV)
+    journal.seek_realtime(time.time() - timespan)
+    return auth_results(entry['MESSAGE'] for entry in journal)
+
+
+class AuthResult(enum.Enum):
+    SUCCESS = 1
+    FAILURE = 2
+
+
+def auth_results(records):
+    """
+    Check authentication results for the specified iterable of records.
+    """
+    results = collections.defaultdict(
+        lambda: {'successful': 0, 'failed': 0},
+    )
+    for record in records:
+        user, result = auth_result(record)
+        if result is AuthResult.SUCCESS:
+            results[user]['successful'] += 1
+        elif result is AuthResult.FAILURE:
+            results[user]['failed'] += 1
+        else:
+            continue
+    return results
+
+
+def auth_result(record) -> typing.Tuple[str, AuthResult]:
+    """
+    Parse authentication result from a single journal record.
+
+    :returns: A tuple of (user, AuthResult.SUCCESS|AuthResult.FAILURE).
+        Both can be None.
+    """
+    user = result = None
+    if 'authentication failure' in record:
+        # Possible records:
+        # Mar 08 03:31:12 wott0 sshd[4698]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=192.168.x.y  # noqa
+        # Jun 29 17:07:45 SVA1 sshd[15588]: PAM 1 more authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=pik.spbstu.ru user=vladik  # noqa
+        _, rest = record.split('; ', 1)
+        tags = dict(pair.split('=') for pair in rest.split(' '))
+        user = tags.get('user', '')
+        result = AuthResult.FAILURE
+    elif 'session opened for user' in record:
+        # Possible records:
+        # Jun 21 06:47:01 debian-server CRON[13006]: pam_unix(cron:session): session opened for user root by (uid=0)
+        user = record.rsplit(' ', 3)[-3]
+        result = AuthResult.SUCCESS
+    return user, result

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,4 @@
+version: '3'
+services:
+  wott-agent:
+    build: .

--- a/tests/test_check_auth.py
+++ b/tests/test_check_auth.py
@@ -1,0 +1,60 @@
+import pytest
+from unittest.mock import patch
+
+from agent.checks import auth
+
+
+class TestAuthResult:
+
+    def test_success(self):
+        record = '# Jun 21 06:47:01 debian-server CRON[13006]: pam_unix(cron:session): session opened for user root by (uid=0)'  # noqa
+        user, result = auth.auth_result(record)
+        assert user == 'root'
+        assert result is auth.AuthResult.SUCCESS
+
+
+    def test_failures(self):
+        record = 'Mar 08 03:31:12 wott0 sshd[4698]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=192.168.x.y'  # noqa
+        user, result = auth.auth_result(record)
+        assert user == ''
+        assert result is auth.AuthResult.FAILURE
+
+        record = 'Jun 29 17:07:45 SVA1 sshd[15588]: PAM 1 more authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=pik.spbstu.ru user=vladik'  # noqa
+        user, result = auth.auth_result(record)
+        assert user == 'vladik'
+        assert result is auth.AuthResult.FAILURE
+
+
+    def test_skip(self):
+        record = 'Some garbage'
+        user, result = auth.auth_result(record)
+        assert user is result is None
+
+
+class TestAuthResults:
+
+    def test_empty_journal(self):
+        results = auth.auth_results([])
+        assert results == {}
+
+    def test_one_entry(self):
+        results = auth.auth_results([
+            '# Jun 21 06:47:01 debian-server CRON[13006]: pam_unix(cron:session): session opened for user ubuntu by (uid=0)',  # noqa
+        ])
+        assert results == {'ubuntu': {'successful': 1, 'failed': 0}}
+
+        results = auth.auth_results([
+            'Mar 08 03:31:12 wott0 sshd[4698]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=192.168.x.y',  # noqa
+        ])
+        assert results == {'': {'successful': 0, 'failed': 1}}
+
+    def test_multiple_entries(self):
+        results = auth.auth_results([
+            '# Jun 21 06:47:01 debian-server CRON[13006]: pam_unix(cron:session): session opened for user ubuntu by (uid=0)',  # noqa
+            'Mar 08 03:31:12 wott0 sshd[4698]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=192.168.x.y user=ubuntu',  # noqa
+            'Mar 08 03:31:12 wott0 sshd[4698]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=192.168.x.y user=root',  # noqa
+            'Some garbage',
+            'Mar 08 03:31:12 wott0 sshd[4698]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=192.168.x.y user=root',  # noqa
+        ])
+        assert results == {'root': {'successful': 0, 'failed': 2},
+                           'ubuntu': {'successful': 1, 'failed': 1}}


### PR DESCRIPTION
Hi, this is my code & tests for assignment. Closes #12 
I decided to create a sub-package `checks` because it's obvious more different checks are coming. So the idea is that each module in `checks` sub-package has `check` function that can be called somewhat universally across all possible checks.
As requested, I have implemented unit tests for the pure logic part of the code. Testing `check` function itself will be considered integration testing.

I have also updated `Dockerfile` (so the container actually starts without errors), and added `docker-compose.yml` for convenience).