### PR TITLE
dev mode: SSL_CLIENT_* -> SSL-CLIENT-*

### DIFF
--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -244,8 +244,8 @@ def send_ping(debug=False, dev=False):
         cert=(CLIENT_CERT_PATH, CLIENT_KEY_PATH),
         json=payload,
         headers={
-            'SSL_CLIENT_SUBJECT_DN': 'CN=' + get_device_id(),
-            'SSL_CLIENT_VERIFY': 'SUCCESS'
+            'SSL-CLIENT-SUBJECT-DN': 'CN=' + get_device_id(),
+            'SSL-CLIENT-VERIFY': 'SUCCESS'
         } if dev else {}
     )
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wott-agent (0.1.2+ppa13) stable; urgency=medium
+
+  * Fix SSL-CLIENT-* headers in dev mode.
+
+ -- Artem Martynovich <artem.martynovich@gmail.com>  Mon, 29 Apr 2019 18:04:49 +0000
+
 wott-agent (0.1.2+ppa12) stable; urgency=medium
 
   * Don't send processes as the server is not ready for that yet.


### PR DESCRIPTION
For security reasons all WSGI environments, including django runserver, strip HTTP headers which contain underscores. Gunicorn does not, that's why it worked.
See https://www.djangoproject.com/weblog/2015/jan/13/security/ and CVE-2015-0219.
deb: 0.1.2+ppa13