### PR TITLE
Updating WoTT Agent Google IoT Core Example Documentation

### DIFF
--- a/docs/examples/google-core-iot/README.md
+++ b/docs/examples/google-core-iot/README.md
@@ -41,7 +41,7 @@ $ export DEVICE_ID=mydevice.d.wott.local
 $ curl -s "https://api.wott.io/v0.2/device-cert/$DEVICE_ID"  > device.crt
 ```
 
-If your WoTT ID starts with a number, do the following commands instead:
+Google's Device ID [must start with a letter ([a-zA-Z]))](https://cloud.google.com/iot/docs/requirements#permitted_characters_and_size_requirements). If your WoTT ID starts with a number, you will have do the following commands instead to circumvent this:
 
 
 ```
@@ -53,10 +53,9 @@ $ curl -s "https://api.wott.io/v0.2/device-cert/$DEVICE_ID"  > device.crt
 
 This achieves the same as before but gives you a valid Google Device ID that you can use to communicate with Google's services.
 
-**Note:** Google's Device ID [must start with a letter ([a-zA-Z]))](https://cloud.google.com/iot/docs/requirements#permitted_characters_and_size_requirements).
+**Note:** 
 The WoTT Device ID (the string of characters found in `mydevice`) is unique and registered to your specific device. This ID can start with either a letter *or* a number. 
-
-Therefore, you will need to prefix your devices if your particular WoTT Device ID starts with a number in order for it to be a valid Google Device ID. 
+Therefore, you need to prefix your devices if your particular WoTT Device ID starts with a number in order for it to be a valid Google Device ID. 
 In order to communicate with either WoTT or Google services, you will need to use the corresponding Device ID for each service; however in many cases this will be the same.
 
 With the certificate downloaded, we can now enroll the device (ensure you use the correct Device ID):
@@ -106,7 +105,7 @@ $ sudo -E ./venv/bin/python cloudiot_mqtt_example.py \
     --project=PROJECT_ID \
     --cloud_region=REGION \
     --registry=REGISTRY_ID \
-    --device=GOOGLE_DEVICE_ID \
+    --device=$GOOGLE_DEVICE_ID \
     --private_key_file=/opt/wott/certs/client.key \
     --algorithm ES256 \
     --ca_certs=roots.pem \

--- a/docs/examples/google-core-iot/README.md
+++ b/docs/examples/google-core-iot/README.md
@@ -85,7 +85,7 @@ For information on how to update/rotate the key of your device, you need to issu
 
 To test the connection, we will use Google's [MQTT example code](https://github.com/GoogleCloudPlatform/python-docs-samples/tree/master/iot/api-client/mqtt_example).
 
-On your device, run the following commands
+On your device, run the following commands:
 
 ```
 $ sudo apt install -y git-core python3-pip wget
@@ -100,7 +100,10 @@ $ pip install -r requirements.txt
 $ wget https://pki.google.com/roots.pem
 ```
 
-We have now installed everything we need to start the agent, so let's give it a shot:
+We have now installed everything we need to start the agent, so let's give it a shot with an example.
+You will need to ensure you remain in the current directory. 
+
+Run the following (ensuring you substitute the correct details):
 
 
 ```
@@ -108,7 +111,7 @@ $ sudo -E ./venv/bin/python cloudiot_mqtt_example.py \
     --project=PROJECT_ID \
     --cloud_region=REGION \
     --registry=REGISTRY_ID \
-    --device=DEVICE_ID \
+    --device=GOOGLE_DEVICE_ID \
     --private_key_file=/opt/wott/certs/client.key \
     --algorithm ES256 \
     --ca_certs=roots.pem \
@@ -116,6 +119,7 @@ $ sudo -E ./venv/bin/python cloudiot_mqtt_example.py \
     device_demo
 ```
 
+You should now see that your device is publishing messages.
 
 ## Verify the connection
 

--- a/docs/examples/google-core-iot/README.md
+++ b/docs/examples/google-core-iot/README.md
@@ -35,7 +35,7 @@ The first thing we need to do is to download our the certificate of the device. 
 
 ```
 $ export DEVICE_ID=mydevice.d.wott.local
-$ curl -s "https://api.wott.io/v0.2/device-cert/$DEVICE_ID" | jq -r '.certificate' > device.crt
+$ curl -s "https://api.wott.io/v0.2/device-cert/$DEVICE_ID"
 ```
 
 replacing `mydevice` with the relevant certificate of your device (which can be found on the WoTT dash).

--- a/docs/examples/google-core-iot/README.md
+++ b/docs/examples/google-core-iot/README.md
@@ -30,7 +30,10 @@ That's it. We have now created a WoTT enabled Google CoreIoT registry. Now we ne
 
 ## Enrolling devices
 
-The first thing we need to do is to download the certificate of the device. To do that we issue an API call to WoTT's API:
+The first thing we need to do is to download the certificate of the device. To do that we nned to issue an API call to WoTT's API.
+To do this, you will need the Device ID of the WoTT agent-enabled device. The relevant information of your device can be found on the WoTT Dash. 
+
+If you do not have the dash set up, you can manually retrieve this information via command line using: `$ sudo wott-agent whoami` and substitute that value into `mydevice` as follows:
 
 
 ```
@@ -38,21 +41,7 @@ $ export DEVICE_ID=mydevice.d.wott.local
 $ curl -s "https://api.wott.io/v0.2/device-cert/$DEVICE_ID"  > device.crt
 ```
 
-replacing `mydevice` with the relevant information of your device (which can be found on the WoTT dash). If you do not have the dash set up, you can manually retrieve this information via command line using:
-
-```
-$ sudo wott-agent whoami
-
-```
-and substitute that value into `mydevice`
-
-**Note:** Google's Device ID [must start with a letter ([a-zA-Z]))](https://cloud.google.com/iot/docs/requirements#permitted_characters_and_size_requirements).
-The WoTT Device ID (the string of characters found in `mydevice`) is unique and registered to your specific device. This ID can either start with either a letter *or* a number. 
-
-Therefore, you will need to prefix your devices if your particular WoTT Device ID starts with a number in order for it to be a valid Google Device ID. 
-In order to communicate with either WoTT or Google services, you will need to use the corresponding Device ID for each service, however in many cases this will be the same.
-
-If your WoTT ID **does** start with a number, do the following commands instead:
+If your WoTT ID starts with a number, do the following commands instead:
 
 
 ```
@@ -64,6 +53,11 @@ $ curl -s "https://api.wott.io/v0.2/device-cert/$DEVICE_ID"  > device.crt
 
 This achieves the same as before but gives you a valid Google Device ID that you can use to communicate with Google's services.
 
+**Note:** Google's Device ID [must start with a letter ([a-zA-Z]))](https://cloud.google.com/iot/docs/requirements#permitted_characters_and_size_requirements).
+The WoTT Device ID (the string of characters found in `mydevice`) is unique and registered to your specific device. This ID can start with either a letter *or* a number. 
+
+Therefore, you will need to prefix your devices if your particular WoTT Device ID starts with a number in order for it to be a valid Google Device ID. 
+In order to communicate with either WoTT or Google services, you will need to use the corresponding Device ID for each service; however in many cases this will be the same.
 
 With the certificate downloaded, we can now enroll the device (ensure you use the correct Device ID):
 

--- a/docs/examples/google-core-iot/README.md
+++ b/docs/examples/google-core-iot/README.md
@@ -2,7 +2,7 @@
 
 Before we get started, you need to install the `gcloud` tool. This is used to interact with Google's services. You can find installation instructions [here](https://cloud.google.com/iot/docs/how-tos/getting-started). Follow the instructions for your specific distribution.
 
-You will also need to have at least one device with the [WoTT agent installed](https://https://github.com/WoTTsecurity/agent) if you do not already. This will provide you with your unique device ID and token which can be added to the [WoTT dashboard](https://dash.wott.io) as per instructions.
+You will also need to have at least one device with the [WoTT agent installed](https://https://github.com/WoTTsecurity/agent) if you do not already. This will provide you with your unique Device ID and token which can be added to the [WoTT dashboard](https://dash.wott.io) as per instructions. You will need the Device ID later.
 
 Finally, you also need to have `curl` and `jq` installed (both should be available in your favorite package manager)
 
@@ -38,6 +38,7 @@ $ export DEVICE_ID=mydevice.d.wott.local
 $ curl -s "https://api.wott.io/v0.2/device-cert/$DEVICE_ID" | jq -r '.certificate' > device.crt
 ```
 
+replacing `mydevice` with the relevant certificate of your device (which can be found on the WoTT dash).
 With the certificate downloaded, we can now enroll the device:
 
 ```
@@ -48,7 +49,7 @@ $ gcloud iot devices create "$DEVICE_ID" \
     --public-key path=device.crt,type=es256-x509-pem
 ```
 
-**Note:** Google's Device ID [must start with a letter ([a-zA-Z]))](https://cloud.google.com/iot/docs/requirements#permitted_characters_and_size_requirements), so you might need to prefix your devices, as the WoTT Device ID can start with a latter.
+**Note:** Google's Device ID [must start with a letter ([a-zA-Z]))](https://cloud.google.com/iot/docs/requirements#permitted_characters_and_size_requirements), so you might need to prefix your devices, as the WoTT Device ID can start with a letter.
 
 We now have our first device enrolled. Please do however note that the WoTT uses short-lived certificates (7 days), so you will need to upload these certificates every week.
 

--- a/docs/examples/google-core-iot/README.md
+++ b/docs/examples/google-core-iot/README.md
@@ -1,8 +1,8 @@
 # Using WoTT with Google Core IoT
 
-Before we get started, you need to install the `gcloud` tool. This is used to interact with Google's services. You can find installation instruction [here](https://cloud.google.com/iot/docs/how-tos/getting-started).
+Before we get started, you need to install the `gcloud` tool. This is used to interact with Google's services. You can find installation instructions [here](https://cloud.google.com/iot/docs/how-tos/getting-started). Follow the instructions for your specific distribution.
 
-You also need to have at least one device with the WoTT agent installed (and know the device id of said device).
+You will also need to have at least one device with the [WoTT agent installed](https://https://github.com/WoTTsecurity/agent) if you do not already. This will provide you with your unique device ID and token which can be added to the [WoTT dashboard](https://dash.wott.io) as per instructions.
 
 Finally, you also need to have `curl` and `jq` installed (both should be available in your favorite package manager)
 

--- a/docs/examples/google-core-iot/README.md
+++ b/docs/examples/google-core-iot/README.md
@@ -13,7 +13,7 @@ First we need to get the CA certificate:
 $ curl -s https://api.wott.io/v0.2/ca | jq -r '.ca_certificate' > ca.crt
 ```
 
-Next, we need to create the registry. Substitute `REGISTRY_ID` and `PROJECT_ID` with your corresponding information. You may also want to change the name of the pub/sub topic.
+Next, we need to create the registry. Substitute `REGISTRY_ID` and `PROJECT_ID` with your corresponding information. You may also want to change the name of the pub/sub topic. 
 
 ```
 $ gcloud iot registries create REGISTRY_ID \
@@ -25,7 +25,7 @@ $ gcloud iot registries create REGISTRY_ID \
     --state-pubsub-topic=wott-pubsub
 ```
 
-That's it. We now have created a WoTT enabled Google CoreIoT registry. Now we need to enroll our first device.
+Available regions for Cloud IoT are `us-central1`, `europe-west1`, and `asia-east1`. That's it. We now have created a WoTT enabled Google CoreIoT registry. Now we need to enroll our first device.
 
 
 ## Enrolling devices
@@ -49,7 +49,10 @@ $ gcloud iot devices create "$DEVICE_ID" \
     --public-key path=device.crt,type=es256-x509-pem
 ```
 
-**Note:** Google's Device ID [must start with a letter ([a-zA-Z]))](https://cloud.google.com/iot/docs/requirements#permitted_characters_and_size_requirements), so you might need to prefix your devices, as the WoTT Device ID can start with a letter.
+**Note:** Google's Device ID [must start with a letter ([a-zA-Z]))](https://cloud.google.com/iot/docs/requirements#permitted_characters_and_size_requirements).
+The WoTT Device ID is unique and registered to your device and can either start with either a letter *or* a number. 
+You will need to prefix your devices if your particular WoTT Device ID starts with a number in order for it to be a valid Google Device ID. In order to communicate with either WoTT or Google services, you will need the correct Device ID for each. 
+However, in many cases this will be the same.
 
 We now have our first device enrolled. Please do however note that the WoTT uses short-lived certificates (7 days), so you will need to upload these certificates every week.
 

--- a/docs/examples/google-core-iot/README.md
+++ b/docs/examples/google-core-iot/README.md
@@ -1,6 +1,6 @@
 # Using WoTT with Google Core IoT
 
-Before we get started, you need to install the `gcloud` tool. This is used to interact with Google's services. You can find installation instructions [here](https://cloud.google.com/iot/docs/how-tos/getting-started). Follow the instructions for your specific distribution.
+Before we get started, you will need to install the `gcloud` tool. This is used to interact with Google's services. You can find installation instructions [here](https://cloud.google.com/iot/docs/how-tos/getting-started). Follow the instructions for your specific distribution.
 
 You will also need to have at least one device with the [WoTT agent installed](https://https://github.com/WoTTsecurity/agent) if you do not already. This will provide you with your unique Device ID and token which can be added to the [WoTT dashboard](https://dash.wott.io) as per instructions. You will need the Device ID later.
 
@@ -30,7 +30,7 @@ That's it. We have now created a WoTT enabled Google CoreIoT registry. Now we ne
 
 ## Enrolling devices
 
-The first thing we need to do is to download our the certificate of the device. To do that we issue an API call to WoTT's API:
+The first thing we need to do is to download the certificate of the device. To do that we issue an API call to WoTT's API:
 
 
 ```
@@ -38,12 +38,13 @@ $ export DEVICE_ID=mydevice.d.wott.local
 $ curl -s "https://api.wott.io/v0.2/device-cert/$DEVICE_ID"  > device.crt
 ```
 
-replacing `mydevice` with the relevant information of your device (which can be found on the WoTT dash). If you do not have the dash set up, you can manually retrieve this information via command line using the following command: 
+replacing `mydevice` with the relevant information of your device (which can be found on the WoTT dash). If you do not have the dash set up, you can manually retrieve this information via command line using:
 
 ```
 $ sudo wott-agent whoami
 
 ```
+and substitute that value into `mydevice`
 
 **Note:** Google's Device ID [must start with a letter ([a-zA-Z]))](https://cloud.google.com/iot/docs/requirements#permitted_characters_and_size_requirements).
 The WoTT Device ID (the string of characters found in `mydevice`) is unique and registered to your specific device. This ID can either start with either a letter *or* a number. 
@@ -131,10 +132,15 @@ gcloud iot devices configs describe \
     --region=REGION \
     --registry=REGISTRY_ID \
     --device=DEVICE_ID
+```
 
+You should get a response similar to this: 
+
+```
 cloudUpdateTime: '2019-01-30T08:51:10.896665Z'
 deviceAckTime: '2019-01-30T11:57:15.586890Z'
 version: '1'
+
 ```
 
 ## Send a message


### PR DESCRIPTION
- Re-organised bulk of documentation up until line 118 to make documentation more cohesive and readable.

- Added reference to WoTT Dash on line 5.

- Added line specifying how to obtain WoTT ID via terminal command `$ sudo wott-agent whoami` on line 44

- Removed `sed` command after `$ curl -s "https://api.wott.io/v0.2/device-cert/$DEVICE_ID"  > device.crt` on line 41 as device certificate NOT in JSON format but x509.

- Introduced use-case scenario where WoTT Device ID is not compatible with Google Device ID (WoTT ID starts with a number not a letter) and relevant bash fix:
 `export GOOGLE_DEVICE_ID=$(echo $DEVICE_ID | sed 's/^[0-9]/a-/g')` (lines 46 to 57). Adds a letter to the beginning of WoTT ID to meet Google Requirements

- Updated note denoting differences between Google Device ID and WoTT Device ID. Google Device ID *must* start with a letter whereas WoTT can be either a number or letter. The different IDs are needed when communicating with either Google or WoTT services.

- Updated  device enrolment and connection to reflect this change. Device now enrolled and connected explicitly by `GOOGLE_DEVICE_ID` in case where WoTT Device ID begins with a number (lines 65 and 109).

- `var/snap/wott-agent/current/client.key` replaced with `opt/wott/certs/client.key` shifting over to Debian tools (line 115) in device demo set up.

- Additional changes include small formatting and legibility improvements.