### PR TITLE
RE: agent #128 - Updating Simple WebApp Example Documentation 

### DIFF
--- a/docs/examples/simple-webapp/README.md
+++ b/docs/examples/simple-webapp/README.md
@@ -60,7 +60,7 @@ and then follow it up with the tunnel command from above.
 
 ## Setting up the client
 
-With the server up and running, we can now move on to the client. This should be another device (either another Raspberry Pi, or a desktop running Debian).
+With the server up and running, we can now move on to the client. This should be *another* device (either Raspberry Pi, or a desktop running Debian).
 
 In order to connect to the server, we need to know the following:
 
@@ -94,4 +94,4 @@ Hello from WoTT!
 
 ## Closing notes
 
-We have now proven how easy it is to setup a secure connection between two devices using WoTT. The WebApp above can simply be replaced with any other application. Just be mindful of that you should always bind your WebApp to on localhost to prevent it from being exposed to the world insecurely.
+We have now proven how easy it is to setup a secure connection between two devices using WoTT. The WebApp above can simply be replaced with any other application. Just be mindful of that you should always bind your WebApp to localhost to prevent it from being exposed to the world insecurely.

--- a/docs/examples/simple-webapp/README.md
+++ b/docs/examples/simple-webapp/README.md
@@ -48,15 +48,15 @@ $ ghostunnel server \
     ${CONNECTION_POLICY:---allow-all} $@
 ```
 
-This will create a secure reverse proxy that redirects incoming traffic on port 8443 to the WebApp we started earlier (which is listening on localhost:8080). This will also automagically secure the service using mTLS. Hence, this means that not only is the connection encrypted and secure, it also doubles as a replacement for credentials since we can cryptographically identify the device making the request.
+This will create a secure reverse proxy that redirects incoming traffic on port 8443 to the WebApp we started earlier in the first session (listening at localhost:8080). This will also automatically secure the service using mTLS. Hence, this means that not only is the connection encrypted and secure, it also doubles as a replacement for credentials since we can cryptographically identify the device making the request.
 
-By default, the example allow will allow all clients with a valid certificate signed by WoTT. If we want to lock down the service further, we can for set a policy such that only a given device can access it using:
-
-```
-$ export CONNECTION_POLICY='--allow-cn=mydevice.d.wott.local'
+By default, the example will allow all clients with a valid certificate signed by WoTT to make connections to the device. If we want to lock down the service further, we can for set a policy such that only a given device can access it using:
 
 ```
-and then follow it up with the same command as above to establish the tunnel.
+$ export CONNECTION_POLICY='--allow-cn=givendevice.d.wott.local'
+
+```
+and then follow it up with the tunnel command from above.
 
 ## Setting up the client
 
@@ -65,7 +65,7 @@ With the server up and running, we can now move on to the client. This should be
 In order to connect to the server, we need to know the following:
 
  * The IP of the device running the server
- * The WoTT ID of the server (you can get this by running `wott-agent.whoami`)
+ * The WoTT ID of the server (you can get this by running `wott-agent whoami`)
 
 Once we have this information, all we need to do is to start the client by running:
 

--- a/docs/examples/simple-webapp/README.md
+++ b/docs/examples/simple-webapp/README.md
@@ -53,10 +53,10 @@ This will create a secure reverse proxy that redirects incoming traffic on port 
 By default, the example allow will allow all clients with a valid certificate signed by WoTT. If we want to lock down the service further, we can for set a policy such that only a given device can access it using:
 
 ```
-$ export CONNECTION_POLICY='--allow-cn=x.d.wott.local'
-$ wott-agent.server
-[...]
+$ export CONNECTION_POLICY='--allow-cn=mydevice.d.wott.local'
+
 ```
+and then follow it up with the same command as above to establish the tunnel.
 
 ## Setting up the client
 

--- a/docs/examples/simple-webapp/README.md
+++ b/docs/examples/simple-webapp/README.md
@@ -65,16 +65,26 @@ With the server up and running, we can now move on to the client. This should be
 In order to connect to the server, we need to know the following:
 
  * The IP of the device running the server
- * The WoTT ID of the server (you can get this by running `wott-agent whoami`)
+ * The WoTT ID of the server (you can get this by running `wott-agent whoami` or by checking your (WoTT Dashboard)[dash.wott.io] if you have it registered)
 
 Once we have this information, all we need to do is to start the client by running:
 
 ```
 $ export TARGET_IP=192.168.a.b
-$ export TARGET_WOTT_ID=y.d.wott.local
-$ wott-agent.client
-[...]
+$ export TARGET_WOTT_ID=serverdevice.d.wott.local
+
+$ set -euo pipefail
+$ IFS=$'\n\t'
+
+$ ghostunnel client \
+    --listen 127.0.0.1:${LISTEN_PORT:-8080} \
+    --target ${TARGET_IP}:${TARGET_PORT:-8443} \
+    --override-server-name=${TARGET_WOTT_ID} \
+    --keystore "$SNAP_DATA/combined.pem" \
+    --cacert "$SNAP_DATA/ca.crt"
 ```
+
+where `a` and `b` correspond to your own private IP (normally found on the back of a router).
 
 Assuming you don't get any errors, there should now be an established secure tunnel between the client and server. The client is now proxying any request coming in on 127.0.0.1:8080 securely to the remote server (using mTLS).
 

--- a/docs/examples/simple-webapp/README.md
+++ b/docs/examples/simple-webapp/README.md
@@ -47,13 +47,12 @@ $ ghostunnel server \
 
 This will create a secure reverse proxy that redirects incoming traffic on port 8443 to the WebApp we started earlier in the first session (listening at localhost:8080). This will also automatically secure the service using mTLS. Hence, this means that not only is the connection encrypted and secure, it also doubles as a replacement for credentials since we can cryptographically identify the device making the request.
 
-By default, the example will allow all clients with a valid certificate signed by WoTT to make connections to the device. If we want to lock down the service further, we can for set a policy such that only a given device can access it using:
+By default, the example will allow all clients with a valid certificate signed by WoTT to make connections to the device. If we want to lock down the service further, we can for set a policy such that only a given device can access it using the same ghostunnel command as above but replacing `$$ {CONNECTION_POLICY:---allow-all} $@` with :
 
 ```
-$ export CONNECTION_POLICY='--allow-cn=givendevice.d.wott.local'
+$ CONNECTION_POLICY='--allow-cn=givendevice.d.wott.local'
 
 ```
-and then follow it up with the tunnel command from above.
 
 ## Setting up the client
 
@@ -75,7 +74,8 @@ $ ghostunnel client \
     --cacert "/opt/wott/certs/ca.crt"
 ```
 
-Inserting your the IP Address of the server which you can find by running `ip addr show` and the server device ID into `serverdevice`.
+Inserting your the IP Address of the server which you can get by running`ip addr show` or `ip route get 8.4.4.3`. 
+Use the server WoTT device ID in place of `serverdevice`.
 
 Assuming you don't get any errors, there should now be an established secure tunnel between the client and server. The client is now proxying any request coming in on 127.0.0.1:8080 securely to the remote server (using mTLS).
 

--- a/docs/examples/simple-webapp/README.md
+++ b/docs/examples/simple-webapp/README.md
@@ -70,21 +70,18 @@ In order to connect to the server, we need to know the following:
 Once we have this information, all we need to do is to start the client by running:
 
 ```
-$ export TARGET_IP=192.168.a.b
-$ export TARGET_WOTT_ID=serverdevice.d.wott.local
-
 $ set -euo pipefail
 $ IFS=$'\n\t'
 
 $ ghostunnel client \
     --listen 127.0.0.1:${LISTEN_PORT:-8080} \
-    --target ${TARGET_IP}:${TARGET_PORT:-8443} \
-    --override-server-name=${TARGET_WOTT_ID} \
+    --target ${192.168.a.b}:${TARGET_PORT:-8443} \
+    --override-server-name=${serverdevice.d.wott.local} \
     --keystore "$SNAP_DATA/combined.pem" \
     --cacert "$SNAP_DATA/ca.crt"
 ```
 
-where `a` and `b` correspond to your own private IP (normally found on the back of a router).
+where `a` and `b` correspond to your own private IP (normally found on the back of a router) and you insert the server device ID into `serverdevice`.
 
 Assuming you don't get any errors, there should now be an established secure tunnel between the client and server. The client is now proxying any request coming in on 127.0.0.1:8080 securely to the remote server (using mTLS).
 

--- a/docs/examples/simple-webapp/README.md
+++ b/docs/examples/simple-webapp/README.md
@@ -4,14 +4,14 @@
 
 In the following example, we'll walk you through how to secure a simple WebApp using WoTT.
 
-Before you begin, you need two devices with the [WoTT Agent installed](https://github.com/WoTTsecurity/agent). This can be either two Raspberry Pis; or a Raspberry Pi and a desktop computer running a Debian distribution of Linux.
+Before you begin, you need two devices with the [WoTT Agent installed](https://github.com/WoTTsecurity/agent). This can be a combination of devices that are either a Raspberry Pi or a desktop running a Debian distribution of Linux.
 
-The first thing that we will do is to setup a simple Python WebApp on a Raspberry Pi.
+The first thing that we need to do is to setup a simple Python WebApp on a Raspberry Pi. The following example is taken from the [WoTT Github](https://github.com/WoTTsecurity/agent).
 
 ## Setting up the WebApp
 
 ```
-$ apt-get update && apt-get install -y python3 python3-pip curl
+$ apt update && apt install -y python3 python3-pip curl
 $ mkdir ~/wott-webapp-example
 $ cd ~/wott-webapp-example
 $ curl -o app.py https://raw.githubusercontent.com/WoTTsecurity/agent/master/docs/examples/simple-webapp/app.py

--- a/docs/examples/simple-webapp/README.md
+++ b/docs/examples/simple-webapp/README.md
@@ -37,14 +37,11 @@ To solve this, we can secure this service using the WoTT agent. To do this, we c
 While still leaving the session with our WebApp running, run the following command in a separate terminal:
 
 ```
-$ set -euo pipefail
-$ IFS=$'\n\t'
-
 $ ghostunnel server \
     --listen 0.0.0.0:${LISTEN_PORT:-8443} \
     --target 127.0.0.1:${TARGET_PORT:-8080} \
-    --keystore "$SNAP_DATA/combined.pem" \
-    --cacert "$SNAP_DATA/ca.crt" \
+    --keystore "$/opt/wott/certs/combined.pem" \
+    --cacert "$/opt/wott/certs/ca.crt" \
     ${CONNECTION_POLICY:---allow-all} $@
 ```
 
@@ -70,15 +67,12 @@ In order to connect to the server, we need to know the following:
 Once we have this information, all we need to do is to start the client by running:
 
 ```
-$ set -euo pipefail
-$ IFS=$'\n\t'
-
 $ ghostunnel client \
     --listen 127.0.0.1:${LISTEN_PORT:-8080} \
     --target ${192.168.a.b}:${TARGET_PORT:-8443} \
     --override-server-name=${serverdevice.d.wott.local} \
-    --keystore "$SNAP_DATA/combined.pem" \
-    --cacert "$SNAP_DATA/ca.crt"
+    --keystore "$/opt/wot/certs/combined.pem" \
+    --cacert "$/opt/wott/certs/ca.crt"
 ```
 
 where `a` and `b` correspond to your own private IP (normally found on the back of a router) and you insert the server device ID into `serverdevice`.

--- a/docs/examples/simple-webapp/README.md
+++ b/docs/examples/simple-webapp/README.md
@@ -4,7 +4,7 @@
 
 In the following example, we'll walk you through how to secure a simple WebApp using WoTT.
 
-Before you begin, you need two devices with the [WoTT Agent installed](https://github.com/WoTTsecurity/agent). This can be either two Raspberry Pis, or a Raspberry Pi and a desktop computer running Linux.
+Before you begin, you need two devices with the [WoTT Agent installed](https://github.com/WoTTsecurity/agent). This can be either two Raspberry Pis; or a Raspberry Pi and a desktop computer running a Debian distribution of Linux.
 
 The first thing that we will do is to setup a simple Python WebApp on a Raspberry Pi.
 

--- a/docs/examples/simple-webapp/README.md
+++ b/docs/examples/simple-webapp/README.md
@@ -50,9 +50,11 @@ This will create a secure reverse proxy that redirects incoming traffic on port 
 By default, the example will allow all clients with a valid certificate signed by WoTT to make connections to the device. If we want to lock down the service further, we can for set a policy such that only a given device can access it using the same ghostunnel command as above but replacing `$ {CONNECTION_POLICY:---allow-all} $@` with :
 
 ```
-$ CONNECTION_POLICY='--allow-cn=givendevice.d.wott.local'
+$ {CONNECTION_POLICY=--allow-cn=givendevice.d.wott.local} $@
 
 ```
+**Note:**
+If you are being denied permissions, use `sudo` before starting the ghostunnel.
 
 ## Setting up the client
 

--- a/docs/examples/simple-webapp/README.md
+++ b/docs/examples/simple-webapp/README.md
@@ -60,7 +60,7 @@ and then follow it up with the tunnel command from above.
 
 ## Setting up the client
 
-With the server up and running, we can now move on to the client. This should be another device (either another Raspberry Pi, or a desktop running Linux).
+With the server up and running, we can now move on to the client. This should be another device (either another Raspberry Pi, or a desktop running Debian).
 
 In order to connect to the server, we need to know the following:
 

--- a/docs/examples/simple-webapp/README.md
+++ b/docs/examples/simple-webapp/README.md
@@ -28,9 +28,9 @@ $ curl http://localhost:8080
 Hello from WoTT!
 ```
 
-This webserver is however insecure. The traffic to it is fully unencrypted. When communicating within the same device, this isn't a major security problem, but as soon as the communication leaves the local device (such as over the network, or even worse, over the internet), this becomes a big problem. It's then prone to a number of attacks, such as eavesdropping and impersonation attacks.
+However this webserver is insecure- the traffic to it is fully unencrypted. When communicating within the same device, this isn't a major security problem; but as soon as the communication leaves the local device (such as over the network, or even worse, over the internet), this becomes a big problem. It's then prone to a number of attacks, such as eavesdropping and impersonation attacks.
 
-To solve this, let's secure this service using the WoTT agent. To do this, we can either create a tunnel between the agent and server, or use the WoTT certificates directly in the client (such as in `curl`.). In this example, we'll opt for the former option (i.e. a tunnel).
+To solve this, we can secure this service using the WoTT agent. To do this, we can either create a tunnel between the agent and server, or use the WoTT certificates directly in the client (such as in `curl`). In this example, we'll opt for the former option (i.e. a tunnel).
 
 ## Setting up the server
 

--- a/docs/examples/simple-webapp/README.md
+++ b/docs/examples/simple-webapp/README.md
@@ -4,7 +4,7 @@
 
 In the following example, we'll walk you through how to secure a simple WebApp using WoTT.
 
-Before you begin, you need two devices with the [WoTT Agent Snap installed](https://github.com/WoTTsecurity/agent#snap-runtime-recommended). This can be either two Raspberry Pis, or a Raspberry Pi and a desktop computer running Linux.
+Before you begin, you need two devices with the [WoTT Agent installed](https://github.com/WoTTsecurity/agent). This can be either two Raspberry Pis, or a Raspberry Pi and a desktop computer running Linux.
 
 The first thing that we will do is to setup a simple Python WebApp on a Raspberry Pi.
 

--- a/docs/examples/simple-webapp/README.md
+++ b/docs/examples/simple-webapp/README.md
@@ -47,7 +47,7 @@ $ ghostunnel server \
 
 This will create a secure reverse proxy that redirects incoming traffic on port 8443 to the WebApp we started earlier in the first session (listening at localhost:8080). This will also automatically secure the service using mTLS. Hence, this means that not only is the connection encrypted and secure, it also doubles as a replacement for credentials since we can cryptographically identify the device making the request.
 
-By default, the example will allow all clients with a valid certificate signed by WoTT to make connections to the device. If we want to lock down the service further, we can for set a policy such that only a given device can access it using the same ghostunnel command as above but replacing `$$ {CONNECTION_POLICY:---allow-all} $@` with :
+By default, the example will allow all clients with a valid certificate signed by WoTT to make connections to the device. If we want to lock down the service further, we can for set a policy such that only a given device can access it using the same ghostunnel command as above but replacing `$ {CONNECTION_POLICY:---allow-all} $@` with :
 
 ```
 $ CONNECTION_POLICY='--allow-cn=givendevice.d.wott.local'

--- a/docs/examples/simple-webapp/README.md
+++ b/docs/examples/simple-webapp/README.md
@@ -40,8 +40,8 @@ While still leaving the session with our WebApp running, run the following comma
 $ ghostunnel server \
     --listen 0.0.0.0:${LISTEN_PORT:-8443} \
     --target 127.0.0.1:${TARGET_PORT:-8080} \
-    --keystore "$/opt/wott/certs/combined.pem" \
-    --cacert "$/opt/wott/certs/ca.crt" \
+    --keystore "/opt/wott/certs/combined.pem" \
+    --cacert "/opt/wott/certs/ca.crt" \
     ${CONNECTION_POLICY:---allow-all} $@
 ```
 
@@ -69,13 +69,13 @@ Once we have this information, all we need to do is to start the client by runni
 ```
 $ ghostunnel client \
     --listen 127.0.0.1:${LISTEN_PORT:-8080} \
-    --target ${192.168.a.b}:${TARGET_PORT:-8443} \
-    --override-server-name=${serverdevice.d.wott.local} \
-    --keystore "$/opt/wot/certs/combined.pem" \
-    --cacert "$/opt/wott/certs/ca.crt"
+    --target MY_IP:${TARGET_PORT:-8443} \
+    --override-server-name=serverdevice.d.wott.local \
+    --keystore "/opt/wot/certs/combined.pem" \
+    --cacert "/opt/wott/certs/ca.crt"
 ```
 
-where `a` and `b` correspond to your own private IP (normally found on the back of a router) and you insert the server device ID into `serverdevice`.
+Inserting your the IP Address of the server which you can find by running `ip addr show` and the server device ID into `serverdevice`.
 
 Assuming you don't get any errors, there should now be an established secure tunnel between the client and server. The client is now proxying any request coming in on 127.0.0.1:8080 securely to the remote server (using mTLS).
 


### PR DESCRIPTION
- Introducing changes moving from the snap WoTT agent to Debian WoTT agent. Changed to reflect only Debian systems compatible. 
Some minor spelling and grammar fixes included. General clarification to documentation added to make it more cohesive and understandable.

- Changed link from [WoTT snap agent](https://github.com/WoTTsecurity/agent#snap-runtime-recommended) and replaced with [WoTT Agent](https://github.com/WoTTsecurity/agent).

- Line 40: `wott-agent.server` command part of WoTT Agent Snap. Replaced with the ghostunnel script contained.

- Removed 
```set -euo pipefail
IFS=$'\n\t'
``` 
from ghostunnel script.

-ghostunnel scripts fixed to reflect Snap to Debian change.

- Changed server IP from `192.168.a.b` to more general `MY_IP` as not all IP in this form.

- Line 56: Changed syntax from `x.d.wott.local` to`givendevice.d.wott.local` to be more clear and consistent with other documents.

- Line 68: Replaced snap command `wott-agent.whoami` with debian `wott-agent whoami` .