### PR TITLE
Fix revoke interaction with device

### DIFF
--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -208,9 +208,13 @@ def get_ca_cert(debug=False):
 
 def get_claim_token(debug=False, dev=False):
     setup_endpoints(dev, debug)
-    response = requests.get('{}/v0.2/claimed'.format(MTLS_ENDPOINT), cert=(CLIENT_CERT_PATH, CLIENT_KEY_PATH),
-                            headers={'SSL-CLIENT-SUBJECT-DN': 'CN=' + get_device_id(),
-                                     'SSL-CLIENT-VERIFY': 'SUCCESS'} if dev else {})
+    try:
+        response = requests.get('{}/v0.2/claimed'.format(MTLS_ENDPOINT), cert=(CLIENT_CERT_PATH, CLIENT_KEY_PATH),
+                                headers={'SSL-CLIENT-SUBJECT-DN': 'CN=' + get_device_id(),
+                                         'SSL-CLIENT-VERIFY': 'SUCCESS'} if dev else {})
+    except requests.exceptions.ConnectionError:
+        print('Did not manage to get claim info from the server.')
+        exit(2)
     if debug:
         print("[RECEIVED] Get Device Claim Info: {}".format(response))
 
@@ -222,7 +226,7 @@ def get_claim_token(debug=False, dev=False):
         return claim_info['claim_token']
     else:
         print('Did not manage to get claim info from the server.')
-        exit(1)
+        exit(2)
 
 
 def get_fallback_token():

--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -208,6 +208,7 @@ def get_ca_cert(debug=False):
 
 def get_claim_token(debug=False, dev=False):
     setup_endpoints(dev, debug)
+    can_read_cert()
     try:
         response = requests.get('{}/v0.2/claimed'.format(MTLS_ENDPOINT), cert=(CLIENT_CERT_PATH, CLIENT_KEY_PATH),
                                 headers={'SSL-CLIENT-SUBJECT-DN': 'CN=' + get_device_id(),

--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -139,29 +139,7 @@ def generate_device_id(debug=False):
     return device_id_request['device_id']
 
 
-def get_remote_claim_status(debug=False):
-    """
-    Returns the WoTT Device Claim status from the back-end
-    """
-
-    is_claimed_request = requests.get(
-        '{}/v0.2/claimed'.format(MTLS_ENDPOINT),
-        cert=(CLIENT_CERT_PATH, CLIENT_KEY_PATH),
-        headers={
-            'SSL-CLIENT-SUBJECT-DN': 'CN=' + get_device_id(),
-            'SSL-CLIENT-VERIFY': 'SUCCESS'
-        } if True else {}
-    )
-    if debug:
-        print("[RECEIVED] Get Device Claim Status: {}".format(is_claimed_request))
-
-    if is_claimed_request.ok:
-        return is_claimed_request.json()['claimed']
-    else:
-        return None
-
-
-def get_device_id():
+def get_device_id(debug=False, dev=False):
     """
     Returns the WoTT Device ID (i.e. fqdn) by reading the first subject from
     the certificate on disk.
@@ -228,16 +206,25 @@ def get_ca_cert(debug=False):
     return ca.json()['ca_bundle']
 
 
-def get_claim_token():
-    config = configparser.ConfigParser()
-    config.read(INI_PATH)
-    return config['DEFAULT'].get('claim_token', None)
+def get_claim_info(debug=False, dev=False):
+    setup_endpoints(dev, debug)
+    response = requests.get('{}/v0.2/claimed'.format(MTLS_ENDPOINT), cert=(CLIENT_CERT_PATH, CLIENT_KEY_PATH),
+                            headers={
+                                'SSL-CLIENT-SUBJECT-DN': 'CN=' + get_device_id(),
+                                'SSL-CLIENT-VERIFY': 'SUCCESS'
+                            } if dev else {})
+    if debug:
+        print("[RECEIVED] Get Device Claim Info: {}".format(response))
+
+    if response.ok:
+        return response.json()
+    else:
+        print('Did not manage to get claim info from the server.')
+        exit(1)
 
 
-def get_claim_status():
-    config = configparser.ConfigParser()
-    config.read(INI_PATH)
-    return config['DEFAULT'].getboolean('claimed', False)
+def get_claim_token(debug=False, dev=False):
+    return get_claim_info(debug, dev)['claim_token']
 
 
 def get_fallback_token():
@@ -246,12 +233,16 @@ def get_fallback_token():
     return config['DEFAULT'].get('fallback_token', None)
 
 
-def get_claim_url():
-    return '{WOTT_ENDPOINT}/claim-device?device_id={device_id}&claim_token={claim_token}'.format(
-        WOTT_ENDPOINT=DASH_ENDPOINT,
-        device_id=get_device_id(),
-        claim_token=get_claim_token()
-    )
+def get_claim_url(debug=False, dev=False):
+    claim_info = get_claim_info(debug, dev)
+    if claim_info['claimed']:
+        return ''
+    else:
+        return '{WOTT_ENDPOINT}/claim-device?device_id={device_id}&claim_token={claim_token}'.format(
+            WOTT_ENDPOINT=DASH_ENDPOINT,
+            device_id=get_device_id(),
+            claim_token=claim_info['claim_token']
+        )
 
 
 def get_uptime():
@@ -265,7 +256,7 @@ def get_uptime():
     return uptime_seconds
 
 
-def get_open_ports():
+def get_open_ports(debug=False, dev=False):
     connections, ports = security_helper.netstat_scan()
     return ports
 
@@ -336,10 +327,14 @@ def send_ping(debug=False, dev=False):
         return
 
 
-def say_hello():
+def say_hello(debug=False, dev=False):
     hello = requests.get(
         '{}/v0.2/hello'.format(MTLS_ENDPOINT),
         cert=(CLIENT_CERT_PATH, CLIENT_KEY_PATH),
+        headers={
+            'SSL-CLIENT-SUBJECT-DN': 'CN=' + get_device_id(),
+            'SSL-CLIENT-VERIFY': 'SUCCESS'
+        } if dev else {}
     )
     if not hello.ok:
         print('Hello failed.')
@@ -380,7 +375,7 @@ def sign_cert(csr, device_id, debug=False):
         'crt': res['certificate'],
         'claim_token': res['claim_token'],
         'fallback_token': res['fallback_token'],
-        'claimed': False,
+        'claimed': False
     }
 
 
@@ -550,17 +545,6 @@ def run(ping=True, debug=False, dev=False):
             print('Got WoTT ID: {}'.format(device_id))
         else:
             if not time_for_certificate_renewal() and not is_certificate_expired():
-                if not get_claim_status():
-                    claimed = get_remote_claim_status(debug=debug)
-                    if claimed and str(claimed).lower() == 'true':
-                        config = configparser.ConfigParser()
-                        config.read(INI_PATH)
-                        config['DEFAULT']['claim_token'] = ''
-                        config['DEFAULT']['claimed'] = str(claimed)
-                        with open(INI_PATH, 'w') as configfile:
-                            config.write(configfile)
-                        os.chmod(INI_PATH, 0o600)
-
                 if ping:
                     send_ping(debug=debug, dev=dev)
                     time_to_cert_expires = get_certificate_expiration_date() - datetime.datetime.now(datetime.timezone.utc)
@@ -623,11 +607,7 @@ def run(ping=True, debug=False, dev=False):
 
         print("Writing config...")
         config = configparser.ConfigParser()
-        config['DEFAULT'] = {
-            'claim_token': crt['claim_token'] if str(crt['claimed']) == 'False' else '',
-            'fallback_token': crt['fallback_token'],
-            'claimed': crt['claimed'],
-        }
+        config['DEFAULT'] = {'fallback_token': crt['fallback_token']}
         with open(INI_PATH, 'w') as configfile:
             config.write(configfile)
         os.chmod(INI_PATH, 0o600)

--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -209,10 +209,8 @@ def get_ca_cert(debug=False):
 def get_claim_info(debug=False, dev=False):
     setup_endpoints(dev, debug)
     response = requests.get('{}/v0.2/claimed'.format(MTLS_ENDPOINT), cert=(CLIENT_CERT_PATH, CLIENT_KEY_PATH),
-                            headers={
-                                'SSL-CLIENT-SUBJECT-DN': 'CN=' + get_device_id(),
-                                'SSL-CLIENT-VERIFY': 'SUCCESS'
-                            } if dev else {})
+                            headers={'SSL-CLIENT-SUBJECT-DN': 'CN=' + get_device_id(),
+                                     'SSL-CLIENT-VERIFY': 'SUCCESS'} if dev else {})
     if debug:
         print("[RECEIVED] Get Device Claim Info: {}".format(response))
 

--- a/agent/__main__.py
+++ b/agent/__main__.py
@@ -1,8 +1,8 @@
 import argparse
 import asyncio
-from . import run, get_device_id, get_open_ports, say_hello, \
-    get_claim_token, get_claim_url, executor, fetch_credentials, \
-    get_claim_status
+
+from . import run, get_device_id, get_open_ports, say_hello, get_claim_token, get_claim_url, executor
+from . import fetch_credentials
 
 
 def main():
@@ -12,9 +12,7 @@ def main():
         'test-cert': (say_hello, "Validate device certificate."),
         'claim-token': (get_claim_token, "Print claim token."),
         'claim-url': (get_claim_url, "Print claim URL."),
-        'daemon': (run_daemon, "Run as daemon"),
-        'is-claimed': (get_claim_status, "Check if device is already claimed."),
-
+        'daemon': (run_daemon, "Run as daemon")
     }
     help_string = "One of the following:\n\n" + "\n".join(
         ["{: <12} {: <}".format(k, v[1]) for k, v in actions.items()])
@@ -49,7 +47,7 @@ or renews it if necessary.
         run_daemon(debug=args.debug, dev=args.dev)
     else:
         run(ping=False, debug=args.debug, dev=args.dev)
-        print(actions[args.action][0]())
+        print(actions[args.action][0](debug=args.debug, dev=args.dev))
 
 
 PING_INTERVAL = 60 * 60

--- a/debian/postinst
+++ b/debian/postinst
@@ -2,7 +2,8 @@
 
 CLAIM_URL=$(wott-agent claim-url)
 
-if [ $? -ne 0 ]; then
+if [ $? -eq 1 ]
+then
 HELLO="
 Good job installing the wott-agent and welcome to the community of security conscious hardware devs!
 
@@ -15,6 +16,11 @@ For more information, visit wott.io/getting-started or drop us a line at hey@wot
 Regards,
 The WoTT Team
 
+"
+elif [ $? -eq 2 ]
+then
+HELLO="
+Did not manage to get claim info from the server.
 "
 else
 HELLO="

--- a/debian/postinst
+++ b/debian/postinst
@@ -2,7 +2,7 @@
 
 CLAIM_URL=$(wott-agent claim-url)
 
-if [ $? -eq 0 ]; then
+if [ $? -ne 0 ]; then
 HELLO="
 Good job installing the wott-agent and welcome to the community of security conscious hardware devs!
 

--- a/debian/postinst
+++ b/debian/postinst
@@ -1,8 +1,8 @@
 #DEBHELPER#
 
-CLAIMED=$(wott-agent is-claimed)
+CLAIM_URL=$(wott-agent claim-url)
 
-if [ "${CLAIMED}" = "True" ]; then
+if [ ${CLAIM_URL} ]; then
 HELLO="
 Good job installing the wott-agent and welcome to the community of security conscious hardware devs!
 
@@ -25,7 +25,7 @@ You're one step closer to building a secure device. Your device's unique ID is: 
 To unleash the value of WoTT, and to gain insight into the security of your device(s), connect your device at https://dash.wott.io.
 
 You can claim your device in the dashboard by visiting:
-$(wott-agent claim-url)
+${CLAIM_URL}
 
 For more information on how to get started, visit wott.io/getting-started or drop us a line at hey@wott.io.
 

--- a/debian/postinst
+++ b/debian/postinst
@@ -1,8 +1,8 @@
 #DEBHELPER#
 
 CLAIM_RESULT=$(wott-agent claim-url)
-CLAIM_URL=$(printf "${CLAIM_RESULT}" | tail -n1)
 EXIT_CODE=$?
+CLAIM_URL=$(printf "${CLAIM_RESULT}" | tail -n1)
 
 case $EXIT_CODE in
   0) printf "Good job installing the wott-agent and welcome to the community of security conscious hardware devs!

--- a/debian/postinst
+++ b/debian/postinst
@@ -1,27 +1,13 @@
 #DEBHELPER#
 
-CLAIM_URL=$(wott-agent claim-url --dev)
+CLAIM_RESULT=$(wott-agent claim-url)
+CLAIM_URL=$(printf "${CLAIM_RESULT}" | tail -n1)
 EXIT_CODE=$?
 
-if [ $EXIT_CODE -eq 1 ]
-then
-HELLO="Good job installing the wott-agent and welcome to the community of security conscious hardware devs!
+case $EXIT_CODE in
+  0) printf "Good job installing the wott-agent and welcome to the community of security conscious hardware devs!
 
-Your device has already been claimed in the WoTT dashboard (https://dash.wott.io).
-
-Your device's unique ID is: $(wott-agent whoami --dev)
-
-For more information, visit wott.io/getting-started or drop us a line at hey@wott.io.
-
-Regards,
-The WoTT Team"
-elif [ $EXIT_CODE -eq 2 ]
-then
-HELLO="Did not manage to get claim info from the server."
-else
-HELLO="Good job installing the wott-agent and welcome to the community of security conscious hardware devs!
-
-You're one step closer to building a secure device. Your device's unique ID is: $(wott-agent whoami --dev)
+You're one step closer to building a secure device. Your device's unique ID is: $(wott-agent whoami)
 
 To unleash the value of WoTT, and to gain insight into the security of your device(s), connect your device at https://dash.wott.io.
 
@@ -31,7 +17,23 @@ ${CLAIM_URL}
 For more information on how to get started, visit wott.io/getting-started or drop us a line at hey@wott.io.
 
 Regards,
-The WoTT Team"
-fi
+The WoTT Team
+"
+  ;;
+  1) printf "Good job installing the wott-agent and welcome to the community of security conscious hardware devs!
 
-printf "$HELLO\n"
+Your device has already been claimed in the WoTT dashboard (https://dash.wott.io).
+
+Your device's unique ID is: $(wott-agent whoami)
+
+For more information, visit wott.io/getting-started or drop us a line at hey@wott.io.
+
+Regards,
+The WoTT Team
+"
+  ;;
+  *) printf "Failed to get claim status (exit code ${EXIT_CODE}):
+${CLAIM_RESULT}
+"
+  ;;
+esac

--- a/debian/postinst
+++ b/debian/postinst
@@ -1,32 +1,27 @@
 #DEBHELPER#
 
-CLAIM_URL=$(wott-agent claim-url)
+CLAIM_URL=$(wott-agent claim-url --dev)
+EXIT_CODE=$?
 
-if [ $? -eq 1 ]
+if [ $EXIT_CODE -eq 1 ]
 then
-HELLO="
-Good job installing the wott-agent and welcome to the community of security conscious hardware devs!
+HELLO="Good job installing the wott-agent and welcome to the community of security conscious hardware devs!
 
 Your device has already been claimed in the WoTT dashboard (https://dash.wott.io).
 
-Your device's unique ID is: $(wott-agent whoami)
+Your device's unique ID is: $(wott-agent whoami --dev)
 
 For more information, visit wott.io/getting-started or drop us a line at hey@wott.io.
 
 Regards,
-The WoTT Team
-
-"
-elif [ $? -eq 2 ]
+The WoTT Team"
+elif [ $EXIT_CODE -eq 2 ]
 then
-HELLO="
-Did not manage to get claim info from the server.
-"
+HELLO="Did not manage to get claim info from the server."
 else
-HELLO="
-Good job installing the wott-agent and welcome to the community of security conscious hardware devs!
+HELLO="Good job installing the wott-agent and welcome to the community of security conscious hardware devs!
 
-You're one step closer to building a secure device. Your device's unique ID is: $(wott-agent whoami)
+You're one step closer to building a secure device. Your device's unique ID is: $(wott-agent whoami --dev)
 
 To unleash the value of WoTT, and to gain insight into the security of your device(s), connect your device at https://dash.wott.io.
 
@@ -36,9 +31,7 @@ ${CLAIM_URL}
 For more information on how to get started, visit wott.io/getting-started or drop us a line at hey@wott.io.
 
 Regards,
-The WoTT Team
-
-"
+The WoTT Team"
 fi
 
-printf "$HELLO"
+printf "$HELLO\n"

--- a/debian/postinst
+++ b/debian/postinst
@@ -2,7 +2,7 @@
 
 CLAIM_URL=$(wott-agent claim-url)
 
-if [ ${CLAIM_URL} ]; then
+if [ $? -eq 0 ]; then
 HELLO="
 Good job installing the wott-agent and welcome to the community of security conscious hardware devs!
 

--- a/tests/cassettes/test_renew_cert.yaml
+++ b/tests/cassettes/test_renew_cert.yaml
@@ -1,0 +1,46 @@
+interactions:
+- request:
+    body: '{"device_architecture": "x86_64", "fqdn": "localhost", "csr": null, "device_operating_system_version":
+      "4.9.125-linuxkit", "device_operating_system": "Linux", "ipv4_address": "172.18.0.3",
+      "device_id": null, "fallback_token": null}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '231'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.12.4
+    method: POST
+    uri: https://api.wott.io/v0.2/sign-expired-csr
+  response:
+    body:
+      string: '{"device_id":["This field may not be null."]}'
+    headers:
+      Allow:
+      - POST, PUT, PATCH, OPTIONS
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '45'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 19 Jun 2019 08:02:00 GMT
+      Server:
+      - nginx/1.15.8
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
+    status:
+      code: 400
+      message: Bad Request
+version: 1

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -551,25 +551,6 @@ def test_fetch_credentials_no_dir(tmpdir):
             assert json.load(f) == {"key1": "v21"}
 
 
-def test_get_remote_claim_status(tmpdir, cert, key):
-
-    mock_resp = mock.Mock()
-    mock_resp.raise_status = 200
-    mock_resp.json = mock.Mock(
-        return_value={'claimed': 'True'}
-    )
-    mock_resp.return_value.ok = True
-    with mock.patch('builtins.print'), \
-            mock.patch('agent.can_read_cert') as cr, \
-            mock.patch('requests.get') as req:
-
-        cr.return_value = True
-        req.return_value = mock_resp
-        mock_resp.return_value.ok = True
-        claimed = agent.get_remote_claim_status(debug=False)
-        assert claimed == 'True'
-
-
 def _is_parallel(tmpdir, use_lock: bool, use_pairs: bool = False):
     """
     Execute two "sleepers" at once.


### PR DESCRIPTION
https://github.com/WoTTsecurity/api/issues/261
We don't store 'claimed' and 'claim_token' parameters in local config any longer, instead we always request appropriate values from the server.
The primary purpose of those changes was to make agent work properly after its package reinstallation.