### PR TITLE
Fix errors when running/building Snap 

### DIFF
--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -54,7 +54,6 @@ CONFIG_PATH = os.getenv('CONFIG_PATH', '/opt/wott')
 if not os.path.isdir(CONFIG_PATH):
     os.makedirs(CONFIG_PATH)
     os.chmod(CONFIG_PATH, 0o711)
-Locker.LOCKDIR = CONFIG_PATH
 
 # This needs to be adjusted once we have
 # changed the certificate life span from 7 days.

--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -46,10 +46,15 @@ WOTT_DEV_PORT = 8001
 MTLS_DEV_PORT = 8002
 CONFINEMENT = detect_confinement()
 
-# Conditional handling for if we're running
-# inside a Snap.
-CERT_PATH = os.getenv('CERT_PATH', '/opt/wott/certs')
 CONFIG_PATH = os.getenv('CONFIG_PATH', '/opt/wott')
+CERT_PATH = os.getenv('CERT_PATH', os.path.join(CONFIG_PATH, 'certs'))
+CREDENTIALS_PATH = os.getenv('CREDENTIALS_PATH', os.path.join(CONFIG_PATH, 'credentials'))
+
+CLIENT_CERT_PATH = os.path.join(CERT_PATH, 'client.crt')
+CLIENT_KEY_PATH = os.path.join(CERT_PATH, 'client.key')
+CA_CERT_PATH = os.path.join(CERT_PATH, 'ca.crt')
+COMBINED_PEM_PATH = os.path.join(CERT_PATH, 'combined.pem')
+INI_PATH = os.path.join(CONFIG_PATH, 'config.ini')
 
 if not os.path.isdir(CONFIG_PATH):
     os.makedirs(CONFIG_PATH)
@@ -58,13 +63,6 @@ if not os.path.isdir(CONFIG_PATH):
 # This needs to be adjusted once we have
 # changed the certificate life span from 7 days.
 RENEWAL_THRESHOLD = 3
-
-CLIENT_CERT_PATH = os.path.join(CERT_PATH, 'client.crt')
-CLIENT_KEY_PATH = os.path.join(CERT_PATH, 'client.key')
-CA_CERT_PATH = os.path.join(CERT_PATH, 'ca.crt')
-COMBINED_PEM_PATH = os.path.join(CERT_PATH, 'combined.pem')
-INI_PATH = os.path.join(CONFIG_PATH, 'config.ini')
-CREDENTIALS_PATH = os.path.join(CONFIG_PATH, 'credentials')
 
 
 def is_bootstrapping():

--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -27,10 +27,15 @@ from sys import exit
 import pwd
 import glob
 
-try:
-    __version__ = pkg_resources.get_distribution('wott-agent')
-except pkg_resources.DistributionNotFound:
-    __version__ = (Path(__file__).parents[1] / 'VERSION').read_text().strip()
+
+CONFINEMENT = detect_confinement()
+if CONFINEMENT == Confinement.SNAP:
+    __version__ = os.environ['SNAP_VERSION']
+else:
+    try:
+        __version__ = pkg_resources.get_distribution('wott-agent')
+    except pkg_resources.DistributionNotFound:
+        __version__ = (Path(__file__).parents[1] / 'VERSION').read_text().strip()
 
 
 WOTT_ENDPOINT = os.getenv('WOTT_ENDPOINT', 'https://api.wott.io')
@@ -43,11 +48,8 @@ CONFINEMENT = detect_confinement()
 
 # Conditional handling for if we're running
 # inside a Snap.
-if CONFINEMENT == Confinement.SNAP:
-    CONFIG_PATH = CERT_PATH = os.getenv('SNAP_DATA')
-else:
-    CERT_PATH = os.getenv('CERT_PATH', '/opt/wott/certs')
-    CONFIG_PATH = os.getenv('CONFIG_PATH', '/opt/wott')
+CERT_PATH = os.getenv('CERT_PATH', '/opt/wott/certs')
+CONFIG_PATH = os.getenv('CONFIG_PATH', '/opt/wott')
 
 if not os.path.isdir(CONFIG_PATH):
     os.makedirs(CONFIG_PATH)

--- a/setup.py
+++ b/setup.py
@@ -2,9 +2,12 @@ from setuptools import setup, find_packages
 import version
 
 
+static_version, commit_hash, _, build_number = version.version()
+full_version = version.version_string(static_version, commit_hash, build_number)
+
 setup(
     name="wott-agent",
-    version=version.version_string(*version.version()),
+    version=full_version,
 
     author="Viktor Petersson",
     author_email="v@viktopia.io",

--- a/version.py
+++ b/version.py
@@ -10,7 +10,7 @@ def version():
         head = repo.head.object
         msg = head.message
         commit = str(head)
-    except ModuleNotFoundError:
+    except ImportError:
         commit = None
     build_number = getenv('CIRCLE_BUILD_NUM', '0')
     return ver, msg, commit, build_number

--- a/version.py
+++ b/version.py
@@ -11,7 +11,7 @@ def version():
         msg = head.message
         commit = str(head)
     except ImportError:
-        commit = None
+        commit = msg = None
     build_number = getenv('CIRCLE_BUILD_NUM', '0')
     return ver, msg, commit, build_number
 

--- a/version.py
+++ b/version.py
@@ -1,21 +1,24 @@
-from os import getenv
-
-import git
 import textwrap
+from os import getenv
 
 
 def version():
     ver = open('VERSION').read().strip()
-    repo = git.Repo('.')
-    head = repo.head.object
-    msg = head.message
-    commit = str(head)
+    try:
+        import git
+        repo = git.Repo('.')
+        head = repo.head.object
+        msg = head.message
+        commit = str(head)
+    except ModuleNotFoundError:
+        commit = None
     build_number = getenv('CIRCLE_BUILD_NUM', '0')
     return ver, msg, commit, build_number
 
 
 def version_string(ver, msg, commit, n):
-    return '{}.{}~{}'.format(ver, n, commit[:7])
+    return '{}.{}~{}'.format(ver, n, commit[:7]) if commit \
+           else '{}.{}'.format(ver, n)
 
 
 def write_changelog():

--- a/version.py
+++ b/version.py
@@ -3,29 +3,43 @@ from os import getenv
 
 
 def version():
-    ver = open('VERSION').read().strip()
+    """
+    Extract static version part from VERSION file,
+    git HEAD commit hash and message (if git module can be imported) and
+    CircleCI build number.
+    :return: (str, str, str, str)
+    """
+    static_version = open('VERSION').read().strip()
     try:
         import git
-        repo = git.Repo('.')
-        head = repo.head.object
-        msg = head.message
-        commit = str(head)
     except ImportError:
         commit = msg = None
+    else:
+        repo = git.Repo('.')
+        head = repo.head.object
+        commit = str(head)
+        msg = head.message
     build_number = getenv('CIRCLE_BUILD_NUM', '0')
-    return ver, msg, commit, build_number
+    return static_version, commit, msg, build_number
 
 
-def version_string(ver, msg, commit, n):
-    return '{}.{}~{}'.format(ver, n, commit[:7]) if commit \
-           else '{}.{}'.format(ver, n)
+def version_string(static_version, commit_hash, build_number):
+    """
+    Format a full version string version.build_number~commit_hash.
+    :param static_version: manually managed (static) version part, e.g. 0.1.5
+    :param commit_hash: commit hash (optional)
+    :param build_number: build number (doesn't have to be a number
+    :return: str
+    """
+    return '{}.{}~{}'.format(static_version, build_number, commit_hash[:7]) if commit_hash \
+           else '{}.{}'.format(static_version, build_number)
 
 
 def write_changelog():
     import debian.changelog
 
-    ver, msg, commit, n = version()
-    ver_str = version_string(ver, msg, commit, n)
+    ver, commit, msg, build_number = version()
+    ver_str = version_string(ver, commit, build_number)
     ch = debian.changelog.Changelog(open('debian/changelog'))
     ch.new_block(package='wott-agent',
                  version=ver_str,


### PR DESCRIPTION
wottsecurity/wott-agent-snap#4
Use location mapping in core18.
Skip git commit if can't import git.
If running as snap get the version from snap package.