### PR TITLE
refactor agent to use proper logging

### DIFF
--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -10,7 +10,8 @@ import glob
 import logging
 import logging.config
 from math import floor
-from sys import exit, stdout
+from sys import exit
+from sys import stdout
 from pathlib import Path
 
 import requests

--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -8,6 +8,9 @@ import platform
 import socket
 import netifaces
 import json
+import pwd
+import glob
+import logging
 
 from agent import iptables_helper
 from agent import journal_helper
@@ -24,8 +27,7 @@ from cryptography.x509.oid import NameOID
 from math import floor
 from pathlib import Path
 from sys import exit
-import pwd
-import glob
+
 
 
 CONFINEMENT = detect_confinement()
@@ -49,6 +51,8 @@ CONFINEMENT = detect_confinement()
 CONFIG_PATH = os.getenv('CONFIG_PATH', '/opt/wott')
 CERT_PATH = os.getenv('CERT_PATH', os.path.join(CONFIG_PATH, 'certs'))
 CREDENTIALS_PATH = os.getenv('CREDENTIALS_PATH', os.path.join(CONFIG_PATH, 'credentials'))
+LOG_CONFIG_PATH = os.getenv('LOG_CFG_PATH', os.path.join(CONFIG_PATH, 'logging.ini'))
+DAEMON_LOG_CONFIG_PATH = os.getenv('DAEMON_LOG_CFG_PATH', os.path.join(CONFIG_PATH, 'logging.ini'))
 
 CLIENT_CERT_PATH = os.path.join(CERT_PATH, 'client.crt')
 CLIENT_KEY_PATH = os.path.join(CERT_PATH, 'client.key')
@@ -64,6 +68,8 @@ if not os.path.isdir(CONFIG_PATH):
 # This needs to be adjusted once we have
 # changed the certificate life span from 7 days.
 RENEWAL_THRESHOLD = 3
+
+logger = logging.getLogger(__name__)
 
 
 def is_bootstrapping():
@@ -88,11 +94,11 @@ def is_bootstrapping():
 
 def can_read_cert():
     if not os.access(CLIENT_CERT_PATH, os.R_OK):
-        print('Permission denied when trying to read the certificate file.')
+        logger.error('Permission denied when trying to read the certificate file.')
         exit(1)
 
     if not os.access(CLIENT_KEY_PATH, os.R_OK):
-        print('Permission denied when trying to read the key file.')
+        logger.error('Permission denied when trying to read the key file.')
         exit(1)
 
 
@@ -129,7 +135,7 @@ def is_certificate_expired():
     return datetime.datetime.now(datetime.timezone.utc) > get_certificate_expiration_date()
 
 
-def generate_device_id(debug=False):
+def generate_device_id():
     """
     Device ID is generated remotely.
     """
@@ -137,13 +143,12 @@ def generate_device_id(debug=False):
         '{}/v0.2/generate-id'.format(WOTT_ENDPOINT)
     ).json()
 
-    if debug:
-        print("[RECEIVED] Generate Device ID: {}".format(device_id_request))
+    logging.debug("[RECEIVED] Generate Device ID: {}".format(device_id_request))
 
     return device_id_request['device_id']
 
 
-def get_device_id(debug=False, dev=False):
+def get_device_id():
     """
     Returns the WoTT Device ID (i.e. fqdn) by reading the first subject from
     the certificate on disk.
@@ -194,30 +199,29 @@ def generate_cert(device_id):
     }
 
 
-def get_ca_cert(debug=False):
+def get_ca_cert():
     ca = requests.get('{}/v0.2/ca-bundle'.format(WOTT_ENDPOINT))
 
-    if debug:
-        print("[RECEIVED] Get CA Cert: {}".format(ca.status_code))
-        print("[RECEIVED] Get CA Cert: {}".format(ca.content))
+    logger.debug("[RECEIVED] Get CA Cert: {}".format(ca.status_code))
+    logger.debug("[RECEIVED] Get CA Cert: {}".format(ca.content))
 
     if not ca.ok:
-        print('Failed to get CA...')
-        print(ca.status_code)
-        print(ca.content)
+        logger.error('Failed to get CA...')
+        logger.error(ca.status_code)
+        logger.error(ca.content)
         return
 
     return ca.json()['ca_bundle']
 
 
-def get_mtls_header(debug=False, dev=False):
+def get_mtls_header(dev=False):
     return {
-        'SSL-CLIENT-SUBJECT-DN': 'CN=' + get_device_id(debug=debug, dev=dev),
+        'SSL-CLIENT-SUBJECT-DN': 'CN=' + get_device_id(),
         'SSL-CLIENT-VERIFY': 'SUCCESS'
     } if dev else {}
 
 
-def mtls_req_error_log(request_url, req_type, requester_name, response):
+def req_error_log(req_type, requester, response, log_on_ok=False, caller=''):
     """
     logs error of mtls_request functions
     :param request_url: request url string
@@ -226,25 +230,21 @@ def mtls_req_error_log(request_url, req_type, requester_name, response):
     :param response - request response
     :return: None
     """
-    if not requester_name:
-        requester_name = "({})".format(request_url)
-    print("wott-agent :: mtls_request :: [RECEIVED] {} {}: {}".format(
-        requester_name, req_type, response.status_code))
-    print("wott-agent :: mtls_request :: [RECEIVED] {} {}: {}".format(
-        requester_name, req_type, response.content))
+
+    if log_on_ok or not response.ok:
+        logger.debug("{} :: [RECEIVED] {} {}: {}".format(caller, requester, req_type, response.status_code))
+        logger.debug("{} :: [RECEIVED] {} {}: {}".format(caller, requester, req_type, response.content))
 
 
-def mtls_request(method, url, debug=False, dev=False, requester_name=None, debug_on_ok=False,
-                 return_exception=False, **kwargs):
+def mtls_request(method, url, dev=False, requester_name=None, log_on_ok=False, return_exception=False, **kwargs):
     """
     MTLS  Request.request wrapper function.
     :param method = 'get,'put,'post','delete','patch','head','options'
     :param url: request url string (without endpoint)
-    :param debug: if true then log error messages
     :param dev: if true use dev endpoint and dev headers
     :param requester_name: displayed requester id for error messages
-    :param debug_on_ok: if true with debug then log successful response status/content too
-    :param return_exception if true, then returns tuple ( response, None ) or (None, RequestException)
+    :param log_on_ok: if true then log debug message even if response.ok
+    :param return_exception: if true, then returns tuple ( response, None ) or (None, RequestException)
     :return: response or None (if there was exception raised), or tuple (see above, return_exception)
     """
     try:
@@ -252,19 +252,21 @@ def mtls_request(method, url, debug=False, dev=False, requester_name=None, debug
             method,
             '{}/v0.2/{}'.format(MTLS_ENDPOINT, url),
             cert=(CLIENT_CERT_PATH, CLIENT_KEY_PATH),
-            headers=get_mtls_header(debug=debug, dev=dev),
+            headers=get_mtls_header(dev=dev),
             **kwargs
         )
 
-        if (debug_on_ok or not r.ok) and debug:
-            mtls_req_error_log(url, method.upper(), requester_name, r)
+        if not requester_name:
+            requester_name = "({})".format(url)
+
+        req_error_log(method.upper(), requester_name, r, log_on_ok=log_on_ok, caller='mtls_request')
         if return_exception:
             return r, None
         else:
             return r
 
     except requests.exceptions.RequestException as e:
-        print('wott-agent :: mtls_request :: rises exception: {}'.format(e))
+        logger.exception("mtls_request :: rises exception:")
         if return_exception:
             return None, e
         else:
@@ -275,17 +277,16 @@ def get_claim_token(debug=False, dev=False):
     setup_endpoints(dev, debug)
     can_read_cert()
 
-    response = mtls_request('get', 'claimed', debug=debug, dev=dev, requester_name="Get Device Claim Info")
+    response = mtls_request('get', 'claimed', dev=dev, requester_name="Get Device Claim Info")
     if response is None or not response.ok:
-        print('Did not manage to get claim info from the server.')
+        logger.error('Did not manage to get claim info from the server.')
         exit(2)
 
-    if debug:
-        print("[RECEIVED] Get Device Claim Info: {}".format(response))
+    logger.debug("[RECEIVED] Get Device Claim Info: {}".format(response))
 
     claim_info = response.json()
     if claim_info['claimed']:
-        print('The device is already claimed.')
+        logger.info('The device is already claimed.')
         exit(1)
     return claim_info['claim_token']
 
@@ -294,6 +295,11 @@ def get_fallback_token():
     config = configparser.ConfigParser()
     config.read(INI_PATH)
     return config['DEFAULT'].get('fallback_token', None)
+
+def get_ini_log_level():
+    config = configparser.ConfigParser()
+    config.read(INI_PATH)
+    return config['DEFAULT'].get('log_level', None)
 
 
 def get_claim_url(debug=False, dev=False):
@@ -315,18 +321,18 @@ def get_uptime():
     return uptime_seconds
 
 
-def get_open_ports(debug=False, dev=False):
+def get_open_ports(dev=False):
     connections, ports = security_helper.netstat_scan()
     return ports
 
 
-def send_ping(debug=False, dev=False):
+def send_ping(dev=False):
     can_read_cert()
 
-    ping = mtls_request('get', 'ping', debug=debug, dev=dev, requester_name="Ping", debug_on_ok=True)
+    ping = mtls_request('get', 'ping', dev=dev, requester_name="Ping", log_on_ok=True)
 
     if ping is None or not ping.ok:
-        print('Ping failed.')
+        logger.error('Ping failed.')
         return
 
     connections, ports = security_helper.netstat_scan()
@@ -351,7 +357,7 @@ def send_ping(debug=False, dev=False):
     # Things we cannot do in Docker
     if CONFINEMENT not in (Confinement.DOCKER, Confinement.BALENA):
         blocklist = ping.json()
-        iptables_helper.block(blocklist, debug)
+        iptables_helper.block(blocklist)
 
         payload.update({
             'selinux_status': security_helper.selinux_status(),
@@ -368,24 +374,23 @@ def send_ping(debug=False, dev=False):
             'device_model': rpi_metadata['hardware_model'],
         })
 
-    if debug:
-        print("[GATHER] POST Ping: {}".format(payload))
+    logger.debug("[GATHER] POST Ping: {}".format(payload))
 
-    ping = mtls_request('post', 'ping', json=payload, debug=debug, dev=dev, requester_name="Ping", debug_on_ok=True)
+    ping = mtls_request('post', 'ping', json=payload, dev=dev, requester_name="Ping", log_on_ok=True)
 
     if ping is None or not ping.ok:
-        print('Ping failed.')
+        logger.error('Ping failed.')
         return
 
 
 def say_hello(debug=False, dev=False):
-    hello = mtls_request('get', 'hello', debug=debug, dev=dev, requester_name='Hello')
+    hello = mtls_request('get', 'hello', dev=dev, requester_name='Hello')
     if hello is None or not hello.ok:
-        print('Hello failed.')
+        logger.error('Hello failed.')
     return hello.json()
 
 
-def sign_cert(csr, device_id, debug=False):
+def sign_cert(csr, device_id):
     """
     This is the function for the initial certificate generation.
     This is only valid for the first time. Future renewals require the
@@ -408,11 +413,8 @@ def sign_cert(csr, device_id, debug=False):
     )
 
     if not crt_req.ok:
-        print('Failed to submit CSR...')
-        if debug:
-            print("[RECEIVED] Sign Cert: {}".format(crt_req.status_code))
-            print("[RECEIVED] Sign Cert: {}".format(crt_req.content))
-        return
+        logger.error('Failed to submit CSR...')
+        req_error_log('post', 'Sign Cert', crt_req, caller='sign_cert')
 
     res = crt_req.json()
     return {
@@ -423,13 +425,13 @@ def sign_cert(csr, device_id, debug=False):
     }
 
 
-def renew_cert(csr, device_id, debug=False):
+def renew_cert(csr, device_id):
     """
     This is the renewal function. We need to use the existing certificate to
     verify ourselves in order to get a renewed certificate
     """
 
-    print('Attempting to renew certificate...')
+    logger.info('Attempting to renew certificate...')
     can_read_cert()
 
     payload = {
@@ -442,17 +444,10 @@ def renew_cert(csr, device_id, debug=False):
         'ipv4_address': get_primary_ip()
     }
 
-    crt_req = requests.post(
-        '{}/v0.2/sign-csr'.format(MTLS_ENDPOINT),
-        cert=(CLIENT_CERT_PATH, CLIENT_KEY_PATH),
-        json=payload
-    )
+    crt_req = mtls_request('post', 'sign-csr', False, 'Renew Cert', json=payload)
 
-    if not crt_req.ok:
-        print('Failed to submit CSR...')
-        if debug:
-            print("[RECEIVED] Renew Cert: {}".format(crt_req.status_code))
-            print("[RECEIVED] Renew Cert: {}".format(crt_req.content))
+    if crt_req is None or not crt_req.ok:
+        logger.error('Failed to submit CSR...')
         return
 
     res = crt_req.json()
@@ -464,13 +459,13 @@ def renew_cert(csr, device_id, debug=False):
     }
 
 
-def renew_expired_cert(csr, device_id, debug=False):
+def renew_expired_cert(csr, device_id):
     """
     This is the renewal function. We need to use the existing certificate to
     verify ourselves in order to get a renewed certificate
     """
 
-    print('Attempting to renew expired certificate...')
+    logger.info('Attempting to renew expired certificate...')
     can_read_cert()
 
     payload = {
@@ -490,10 +485,8 @@ def renew_expired_cert(csr, device_id, debug=False):
     )
 
     if not crt_req.ok:
-        print('Failed to submit CSR...')
-        if debug:
-            print("[RECEIVED] Renew expired Cert: {}".format(crt_req.status_code))
-            print("[RECEIVED] Renew expired Cert: {}".format(crt_req.content))
+        logger.error('Failed to submit CSR...')
+        req_error_log('post', 'Renew expired Cert', crt_req)
         return
 
     res = crt_req.json()
@@ -505,17 +498,18 @@ def renew_expired_cert(csr, device_id, debug=False):
     }
 
 
-def setup_endpoints(dev, debug):
+def setup_endpoints(dev):
     if dev:
         global WOTT_ENDPOINT, MTLS_ENDPOINT, DASH_ENDPOINT
-        endpoint = os.getenv('WOTT_ENDPOINT', 'http://localhost')
+        endpoint = os.getenv('WOTT_ENDPOINT', 'http://192.168.1.6')
         DASH_ENDPOINT = endpoint + ':' + str(DASH_DEV_PORT)
         WOTT_ENDPOINT = endpoint + ':' + str(WOTT_DEV_PORT) + '/api'
         MTLS_ENDPOINT = endpoint + ':' + str(MTLS_DEV_PORT) + '/api'
-    if debug:
-        print("DASH_ENDPOINT: {}\nWOTT_ENDPOINT: {}\nMTLS_ENDPOINT: {}".format(
-              DASH_ENDPOINT, WOTT_ENDPOINT, MTLS_ENDPOINT
-              ))
+
+    logger.debug(
+        "\nDASH_ENDPOINT: %s\nWOTT_ENDPOINT: %s\nMTLS_ENDPOINT: %s",
+        DASH_ENDPOINT, WOTT_ENDPOINT, MTLS_ENDPOINT
+    )
 
 
 def fetch_device_metadata(debug, dev):
@@ -547,26 +541,26 @@ def fetch_device_metadata(debug, dev):
 
 
 def fetch_credentials(debug, dev):
+def fetch_credentials(dev, logger=logger):
 
     def clear_credentials(path):
         files = glob.glob(os.path.join(path, '**/*.json'), recursive=True)
         for file in files:
             os.remove(os.path.join(path, file))
-            if debug:
-                print("remove...{}".format(file))
+            logger.debug("remove...{}".format(file))
 
     with Locker('credentials'):
-        setup_endpoints(dev, debug)
-        print('Fetching credentials...')
+        setup_endpoints(dev)
+        logger.info('Fetching credentials...')
         can_read_cert()
 
-        credentials_req = mtls_request('get', 'creds', debug=debug, dev=dev, requester_name="Fetch credentials")
+        credentials_req = mtls_request('get', 'creds', dev=dev, requester_name="Fetch credentials")
         if credentials_req is None or not credentials_req.ok:
-            print('Fetching failed.')
+            logger.error('Fetching failed.')
             return
         credentials = credentials_req.json()
 
-        print('Credentials retrieved.')
+        logger.info('Credentials retrieved.')
 
         if not os.path.exists(CREDENTIALS_PATH):
             os.mkdir(CREDENTIALS_PATH, 0o711)
@@ -574,7 +568,7 @@ def fetch_credentials(debug, dev):
             os.chmod(CREDENTIALS_PATH, 0o711)
 
         if not os.path.isdir(CREDENTIALS_PATH):
-            print("There is file named as our credentials dir({}), that's strange...".format(CREDENTIALS_PATH))
+            logger.error("There is file named as our credentials dir(%s), that's strange...", CREDENTIALS_PATH)
             exit(1)
 
         clear_credentials(CREDENTIALS_PATH)
@@ -599,7 +593,7 @@ def fetch_credentials(debug, dev):
                 try:
                     pw = pwd.getpwnam(owner)
                 except KeyError:
-                    print("Warning. There are credentials with wrong owner ({}). Skipped.".format(owner))
+                    logger.warning("There are credentials with wrong owner ({}). Skipped.".format(owner))
                     continue
 
             uid = pw.pw_uid
@@ -609,7 +603,9 @@ def fetch_credentials(debug, dev):
 
             if owner and not os.path.isdir(owner_path):
                 if os.path.exists(owner_path):
-                    print("There is a file with name of system user in credentials directory ({}).".format(owner_path))
+                    logger.error(
+                        "There is a file with name of system user in credentials directory ({}).".format(owner_path)
+                    )
                     exit(1)
                 os.mkdir(owner_path, 0o700)
             os.chown(owner_path, uid, gid)  # update ownership if user existence in system changed
@@ -621,8 +617,7 @@ def fetch_credentials(debug, dev):
                 for cred in credentials_grouped[owner][name]:
                     file_credentials[cred] = credentials_grouped[owner][name][cred]
 
-                if debug:
-                    print('Store credentials to {} \n '.format(credential_file_path))
+                logger.debug('Store credentials to {}'.format(credential_file_path))
 
                 with open(credential_file_path, 'w') as outfile:
                     json.dump(file_credentials, outfile)
@@ -639,61 +634,65 @@ def write_metadata(data, rewrite_file):
     metadata_path.chmod(0o644)
 
 
-def run(ping=True, debug=False, dev=False):
+def run(ping=True, dev=False, logger=logger):
     with Locker('ping'):
-        setup_endpoints(dev, debug)
+        setup_endpoints(dev)
         bootstrapping = is_bootstrapping()
 
         if bootstrapping:
-            device_id = generate_device_id(debug=debug)
-            print('Got WoTT ID: {}'.format(device_id))
+            device_id = generate_device_id()
+            logger.info('Got WoTT ID: {}'.format(device_id))
             write_metadata({'device_id': device_id}, rewrite_file=True)
         else:
             device_id = get_device_id()
             write_metadata({'device_id': device_id}, rewrite_file=False)
             if not time_for_certificate_renewal() and not is_certificate_expired():
                 if ping:
-                    send_ping(debug=debug, dev=dev)
+                    send_ping(dev=dev)
                     time_to_cert_expires = get_certificate_expiration_date() - datetime.datetime.now(datetime.timezone.utc)
-                    print("Certificate expires in {} days and {} hours. No need for renewal. Renewal threshold is set to {} days.".format(
-                        time_to_cert_expires.days,
-                        floor(time_to_cert_expires.seconds / 60 / 60),
-                        RENEWAL_THRESHOLD,
-                    ))
+                    logger.info(
+                        "Certificate expires in {} days and {} hours. No need for renewal."
+                        "Renewal threshold is set to {} days.".format(
+                            time_to_cert_expires.days,
+                            floor(time_to_cert_expires.seconds / 60 / 60),
+                            RENEWAL_THRESHOLD,
+                        )
+                    )
                     exit(0)
                 else:
                     return
-            print('My WoTT ID is: {}'.format(device_id))
+            logger.info('My WoTT ID is: {}'.format(device_id))
 
-        print('Generating certificate...')
+        logger.info('Generating certificate...')
         gen_key = generate_cert(device_id)
 
-        ca = get_ca_cert(debug=debug)
+        ca = get_ca_cert()
         if not ca:
-            print('Unable to retrieve CA cert. Exiting.')
+            logger.error('Unable to retrieve CA cert. Exiting.')
             exit(1)
 
-        print('Submitting CSR...')
+        logger.info('Submitting CSR...')
 
         if bootstrapping:
-            crt = sign_cert(gen_key['csr'], device_id, debug=debug)
+            crt = sign_cert(gen_key['csr'], device_id)
         elif is_certificate_expired():
-            crt = renew_expired_cert(gen_key['csr'], device_id, debug=debug)
+            crt = renew_expired_cert(gen_key['csr'], device_id)
         else:
-            crt = renew_cert(gen_key['csr'], device_id, debug=debug)
+            crt = renew_cert(gen_key['csr'], device_id)
 
         if not crt:
-            print('Unable to sign CSR. Exiting.')
+            logger.error('Unable to sign CSR. Exiting.')
             exit(1)
 
-        print('Got Claim Token: {}'.format(crt['claim_token']))
-        print('Claim your device: {WOTT_ENDPOINT}/claim-device?device_id={device_id}&claim_token={claim_token}'.format(
-            WOTT_ENDPOINT=DASH_ENDPOINT,
-            device_id=device_id,
-            claim_token=crt['claim_token']
+        logger.info('Got Claim Token: {}'.format(crt['claim_token']))
+        logger.info(
+            'Claim your device: {WOTT_ENDPOINT}/claim-device?device_id={device_id}&claim_token={claim_token}'.format(
+                WOTT_ENDPOINT=DASH_ENDPOINT,
+                device_id=device_id,
+                claim_token=crt['claim_token']
+            )
         )
-        )
-        print('Writing certificate and key to disk...')
+        logger.info('Writing certificate and key to disk...')
         with open(CLIENT_CERT_PATH, 'w') as f:
             f.write(crt['crt'])
         os.chmod(CLIENT_CERT_PATH, 0o644)
@@ -711,11 +710,37 @@ def run(ping=True, debug=False, dev=False):
             f.write(crt['crt'])
         os.chmod(COMBINED_PEM_PATH, 0o600)
 
-        print("Writing config...")
+        logger.info("Writing config...")
         config = configparser.ConfigParser()
         config['DEFAULT'] = {'fallback_token': crt['fallback_token']}
         with open(INI_PATH, 'w') as configfile:
             config.write(configfile)
         os.chmod(INI_PATH, 0o600)
 
-        send_ping(debug=debug, dev=dev)
+        send_ping(dev=dev)
+
+
+def setup_logging(
+    path=LOG_CONFIG_PATH,
+    level=logging.INFO,
+    log_format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+):
+    """
+    Setup logging configuration
+    """
+    if os.path.exists(path):
+        logging.config.dictConfig(path)
+    else:
+        logging.basicConfig(level=level, format=log_format)
+
+    log_level = get_ini_log_level()
+    if log_level is not None:
+        try:
+            logging.getLogger().setLevel(log_level)
+        except (ValueError, TypeError):
+            logging.warning(
+                "Invalid log_level (%s) in %s file. Using level (%s)",
+                log_level,
+                INI_PATH,
+                logging.getLevelName(logging.getLogger().getEffectiveLevel())
+            )

--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -740,4 +740,3 @@ def setup_logging(level=logging.INFO, log_format="%(message)s"):
     logging.getLogger('agent').setLevel(log_level)
     logging.getLogger('agent.iptables_helper').setLevel(log_level)
     logging.getLogger('agent.executor').setLevel(log_level)
-

--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -729,7 +729,7 @@ def run(ping=True, dev=False, logger=logger):
         send_ping(dev=dev)
 
 
-def setup_logging(level=logging.INFO, log_format="%(message)s"):
+def setup_logging(level=logging.INFO, log_format="%(message)s", daemon=True):
     """
     Setup logging configuration
     if there is `log_level` item in wott-agent `config.ini` it would be used as actual log level
@@ -748,9 +748,13 @@ def setup_logging(level=logging.INFO, log_format="%(message)s"):
     if filename is not None and filename != 'stdout':
         file_handler = logging.FileHandler(filename=filename)
         handlers.append(file_handler)
-    else:
+
+    if filename is None or filename == 'stdout' or not daemon:
         stdout_handler = logging.StreamHandler(stdout)
         handlers.append(stdout_handler)
+
+    if not daemon:
+        stdout_handler.setFormatter(logging.Formatter("%(message)s"))
 
     logging.basicConfig(level=log_level, format=log_format, handlers=handlers)
 

--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -305,7 +305,6 @@ def get_ini_log_level():
 
 
 def get_ini_log_file():
-    return '/home/pi/agent/lllll.txt'
     config = configparser.ConfigParser()
     config.read(INI_PATH)
     return config['DEFAULT'].get('log_file', None)

--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -148,7 +148,7 @@ def generate_device_id():
     return device_id_request['device_id']
 
 
-def get_device_id():
+def get_device_id(dev=False):
     """
     Returns the WoTT Device ID (i.e. fqdn) by reading the first subject from
     the certificate on disk.
@@ -323,7 +323,7 @@ def get_uptime():
     return uptime_seconds
 
 
-def get_open_ports():
+def get_open_ports(dev=False):
     connections, ports = security_helper.netstat_scan()
     return ports
 

--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -10,7 +10,7 @@ import glob
 import logging
 import logging.config
 from math import floor
-from sys import exit
+from sys import exit, stdout
 from pathlib import Path
 
 import requests
@@ -302,6 +302,13 @@ def get_ini_log_level():
     config = configparser.ConfigParser()
     config.read(INI_PATH)
     return config['DEFAULT'].get('log_level', None)
+
+
+def get_ini_log_file():
+    return '/home/pi/agent/lllll.txt'
+    config = configparser.ConfigParser()
+    config.read(INI_PATH)
+    return config['DEFAULT'].get('log_file', None)
 
 
 def get_claim_url(dev=False):
@@ -728,6 +735,7 @@ def setup_logging(level=logging.INFO, log_format="%(message)s"):
     if there is `log_level` item in wott-agent `config.ini` it would be used as actual log level
     otherwise used value of level parameter
     """
+
     log_level = level
     ini_level = get_ini_log_level()
     if ini_level is not None and isinstance(ini_level, str):
@@ -735,7 +743,16 @@ def setup_logging(level=logging.INFO, log_format="%(message)s"):
         if ini_level in ['CRITICAL', 'ERROR', 'WARN', 'WARNING', 'INFO', 'DEBUG', 'NOTSET']:
             log_level = ini_level
 
-    logging.basicConfig(level=log_level, format=log_format)
+    filename = get_ini_log_file()
+    handlers = []
+    if filename is not None and filename != 'stdout':
+        file_handler = logging.FileHandler(filename=filename)
+        handlers.append(file_handler)
+    else:
+        stdout_handler = logging.StreamHandler(stdout)
+        handlers.append(stdout_handler)
+
+    logging.basicConfig(level=log_level, format=log_format, handlers=handlers)
 
     logging.getLogger('agent').setLevel(log_level)
     logging.getLogger('agent.iptables_helper').setLevel(log_level)

--- a/agent/__main__.py
+++ b/agent/__main__.py
@@ -2,8 +2,8 @@ import argparse
 import asyncio
 import logging
 
-from . import run, get_device_id, get_open_ports, say_hello, get_claim_token, get_claim_url, executor
-from . import fetch_credentials, fetch_device_metadata, setup_logging, logger
+from agent import run, get_device_id, get_open_ports, say_hello, get_claim_token, get_claim_url, executor
+from agent import fetch_credentials, fetch_device_metadata, setup_logging, logger
 
 
 def main():

--- a/agent/__main__.py
+++ b/agent/__main__.py
@@ -2,8 +2,8 @@ import argparse
 import asyncio
 import logging
 
-from agent import run, get_device_id, get_open_ports, say_hello, get_claim_token, get_claim_url, executor
-from agent import fetch_credentials, fetch_device_metadata, setup_logging, logger
+from . import run, get_device_id, get_open_ports, say_hello, get_claim_token, get_claim_url, executor
+from . import fetch_credentials, fetch_device_metadata, setup_logging, logger
 
 
 def main():

--- a/agent/__main__.py
+++ b/agent/__main__.py
@@ -53,7 +53,7 @@ or renews it if necessary.
     else:
         logger.info("start for %s action...", args.action)
         run(ping=False, dev=args.dev)
-        print(actions[args.action][0]())
+        print(actions[args.action][0](dev=args.dev))
 
 
 PING_INTERVAL = 60 * 60

--- a/agent/__main__.py
+++ b/agent/__main__.py
@@ -3,7 +3,7 @@ import asyncio
 import logging
 
 from . import run, get_device_id, get_open_ports, say_hello, get_claim_token, get_claim_url, executor
-from . import fetch_credentials, fetch_device_metadata, setup_logging, logger, DAEMON_LOG_CONFIG_PATH
+from . import fetch_credentials, fetch_device_metadata, setup_logging, logger
 
 
 def main():
@@ -39,7 +39,7 @@ or renews it if necessary.
     args = parser.parse_args()
 
     if args.action == 'daemon':
-        setup_logging(level=logging.INFO, path=DAEMON_LOG_CONFIG_PATH,
+        setup_logging(level=logging.INFO,
                       log_format="%(asctime)s - %(name)s - %(threadName)s - %(levelname)s - %(message)s")
     else:
         setup_logging(level=logging.INFO)
@@ -66,7 +66,7 @@ DEV_MD_TIMEOUT = 1 * 60
 
 def run_daemon(dev):
     exes = [
-        executor.Executor(PING_INTERVAL, run, (True, dev, logger, True), timeout=PING_TIMEOUT),
+        executor.Executor(PING_INTERVAL, run, (True, dev, logger), timeout=PING_TIMEOUT),
         executor.Executor(CREDS_INTERVAL, fetch_credentials, (dev, logger), timeout=CREDS_TIMEOUT),
         executor.Executor(DEV_MD_INTERVAL, fetch_device_metadata, (dev, logger), timeout=DEV_MD_TIMEOUT)
     ]

--- a/agent/__main__.py
+++ b/agent/__main__.py
@@ -42,7 +42,8 @@ or renews it if necessary.
         setup_logging(level=logging.INFO,
                       log_format="%(asctime)s - %(name)s - %(threadName)s - %(levelname)s - %(message)s")
     else:
-        setup_logging(level=logging.INFO)
+        setup_logging(level=logging.INFO, daemon=False,
+                      log_format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
 
     if not args.action:
         logger.info("start in ping mode...")

--- a/agent/__main__.py
+++ b/agent/__main__.py
@@ -51,7 +51,6 @@ or renews it if necessary.
         logger.info("start in daemon mode...")
         run_daemon(dev=args.dev)
     else:
-        logger.info("start for %s action...", args.action)
         run(ping=False, dev=args.dev)
         print(actions[args.action][0](dev=args.dev))
 

--- a/agent/__main__.py
+++ b/agent/__main__.py
@@ -32,11 +32,6 @@ or renews it if necessary.
                         metavar='action',
                         help=help_string)
     parser.add_argument(
-        '--debug',
-        required=False,
-        action="store_true",
-        help="Enable debug output.")
-    parser.add_argument(
         '--dev',
         required=False,
         action="store_true",
@@ -44,9 +39,10 @@ or renews it if necessary.
     args = parser.parse_args()
 
     if args.action == 'daemon':
-        setup_logging(level=logging.INFO if not args.debug else logging.DEBUG, path=DAEMON_LOG_CONFIG_PATH)
+        setup_logging(level=logging.INFO, path=DAEMON_LOG_CONFIG_PATH,
+                      log_format="%(asctime)s - %(name)s - %(threadName)s - %(levelname)s - %(message)s")
     else:
-        setup_logging(level=logging.INFO if not args.debug else logging.DEBUG)
+        setup_logging(level=logging.INFO)
 
     if not args.action:
         logger.info("start in ping mode...")
@@ -71,7 +67,7 @@ DEV_MD_TIMEOUT = 1 * 60
 
 def run_daemon(dev):
     exes = [
-        executor.Executor(PING_INTERVAL, run, (True, dev, logger), timeout=PING_TIMEOUT),
+        executor.Executor(PING_INTERVAL, run, (True, dev, logger, True), timeout=PING_TIMEOUT),
         executor.Executor(CREDS_INTERVAL, fetch_credentials, (dev, logger), timeout=CREDS_TIMEOUT),
         executor.Executor(DEV_MD_INTERVAL, fetch_device_metadata, (dev, logger), timeout=DEV_MD_TIMEOUT)
     ]

--- a/agent/executor.py
+++ b/agent/executor.py
@@ -7,6 +7,7 @@ from multiprocessing import Queue
 from typing import Callable
 from typing import Dict
 from typing import Any
+import logging
 
 
 class Executor():
@@ -19,8 +20,7 @@ class Executor():
                  func, fargs,
                  timeout=None,
                  callback_timeout=None,
-                 daemon=False,
-                 debug=False):
+                 daemon=False):
         """
         Periodic process executor. Calls func and sleeps for interval,
         repeatedly. Kills the process after a timeout.
@@ -39,7 +39,6 @@ class Executor():
         self.process = None
         self.oneshot = interval is None
         self.should_stop = False
-        self.debug = debug
 
     async def start(self):
         """ start calling the process periodically """
@@ -84,8 +83,7 @@ class Executor():
         """
         p_args = fn_args if isinstance(fn_args, tuple) else (fn_args,)
         queue = Queue()
-        if self.debug:
-            print("Executor: starting {} {}".format(func.__name__, p_args))
+        logging.debug("Executor: starting {} {}".format(func.__name__, p_args))
         p = Process(target=self._process_run,
                     args=(queue, func, *p_args,), kwargs=p_kwargs)
 
@@ -100,8 +98,7 @@ class Executor():
         if callback_timeout:
             callback_timeout(*p_args, **p_kwargs)
         if p.is_alive():
-            if self.debug:
-                print('Executor: terminating by timeout')
+            logging.debug('Executor: terminating by timeout')
             p.terminate()
             p.join()
 

--- a/agent/executor.py
+++ b/agent/executor.py
@@ -10,6 +10,7 @@ from typing import Any
 import logging
 logger = logging.getLogger('agent.executor')
 
+
 class Executor():
     MAX_WORKERS = 10
     processes = MAX_WORKERS or os.cpu_count()

--- a/agent/executor.py
+++ b/agent/executor.py
@@ -8,7 +8,7 @@ from typing import Callable
 from typing import Dict
 from typing import Any
 import logging
-
+logger = logging.getLogger('agent.executor')
 
 class Executor():
     MAX_WORKERS = 10
@@ -83,7 +83,7 @@ class Executor():
         """
         p_args = fn_args if isinstance(fn_args, tuple) else (fn_args,)
         queue = Queue()
-        logging.debug("Executor: starting {} {}".format(func.__name__, p_args))
+        logger.debug("Executor: starting {} {}".format(func.__name__, p_args))
         p = Process(target=self._process_run,
                     args=(queue, func, *p_args,), kwargs=p_kwargs)
 
@@ -98,7 +98,7 @@ class Executor():
         if callback_timeout:
             callback_timeout(*p_args, **p_kwargs)
         if p.is_alive():
-            logging.debug('Executor: terminating by timeout')
+            logger.debug('Executor: terminating by timeout')
             p.terminate()
             p.join()
 

--- a/agent/iptables_helper.py
+++ b/agent/iptables_helper.py
@@ -6,6 +6,7 @@ from iptc import IPTCError
 
 from . import iptc_helper
 
+logger = logging.getLogger('agent.iptables_helper')
 
 TABLE = 'filter'
 DROP_CHAIN = 'WOTT_LOG_DROP'
@@ -146,7 +147,6 @@ def block_networks(network_list: List[Tuple[str, bool]]):
 
 
 def block(blocklist):
-    logger = logging.getLogger(__name__)
     policy = blocklist.get('policy', 'allow')
     try:
         prepare()

--- a/agent/iptables_helper.py
+++ b/agent/iptables_helper.py
@@ -5,7 +5,7 @@ from traceback import print_exc
 
 from iptc import IPTCError
 
-from agent import iptc_helper
+from . import iptc_helper
 
 
 TABLE = 'filter'

--- a/agent/iptables_helper.py
+++ b/agent/iptables_helper.py
@@ -1,7 +1,6 @@
 from typing import List, Tuple
 from itertools import product
-from sys import stdout
-from traceback import print_exc
+import logging
 
 from iptc import IPTCError
 
@@ -147,6 +146,7 @@ def block_networks(network_list: List[Tuple[str, bool]]):
 
 
 def block(blocklist):
+    logger = logging.getLogger(__name__)
     policy = blocklist.get('policy', 'allow')
     try:
         prepare()

--- a/agent/iptables_helper.py
+++ b/agent/iptables_helper.py
@@ -5,7 +5,7 @@ from traceback import print_exc
 
 from iptc import IPTCError
 
-from . import iptc_helper
+from agent import iptc_helper
 
 
 TABLE = 'filter'
@@ -146,7 +146,7 @@ def block_networks(network_list: List[Tuple[str, bool]]):
     add_rules(TABLE, OUTPUT_CHAIN, rules)
 
 
-def block(blocklist, debug):
+def block(blocklist):
     policy = blocklist.get('policy', 'allow')
     try:
         prepare()
@@ -157,10 +157,9 @@ def block(blocklist, debug):
             block_ports(False, blocklist.get('allow_ports', []))
             add_block_rules()
         else:
-            print('Error: unknown policy "{}"'.format(policy))
+            logger.error('Error: unknown policy "{}"'.format(policy))
     except IPTCError as e:
-        print('Error while updating iptables: ' + str(e))
-        if debug:
-            print_exc(file=stdout)
+        logger.error('Error while updating iptables: %s', str(e))
+        logger.debug(exc_info=True)
         if 'insmod' in str(e):
-            print('Error: failed to update iptables, try rebooting')
+            logger.error('Error: failed to update iptables, try rebooting')

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -310,8 +310,8 @@ def test_renew_cert(raspberry_cpuinfo, tmpdir, cert, key):
         getfqdn.return_value = 'localhost'
         res = agent.renew_expired_cert(None, None)
         assert res is None
-        assert (prn.info.call_count == 1 and prn.error.call_count == 1
-                and mock.call('Failed to submit CSR...') in prn.error.mock_calls)
+        assert (prn.info.call_count == 1 and prn.error.call_count == 1 and 
+                mock.call('Failed to submit CSR...') in prn.error.mock_calls)
 
 
 @pytest.mark.vcr

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -310,8 +310,7 @@ def test_renew_cert(raspberry_cpuinfo, tmpdir, cert, key):
         getfqdn.return_value = 'localhost'
         res = agent.renew_expired_cert(None, None)
         assert res is None
-        assert (prn.info.call_count == 1 and prn.error.call_count == 1 and
-                mock.call('Failed to submit CSR...') in prn.error.mock_calls)
+        assert (prn.info.call_count == 1 and prn.error.call_count == 1 and mock.call('Failed to submit CSR...') in prn.error.mock_calls)
 
 
 @pytest.mark.vcr

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -310,7 +310,7 @@ def test_renew_cert(raspberry_cpuinfo, tmpdir, cert, key):
         getfqdn.return_value = 'localhost'
         res = agent.renew_expired_cert(None, None)
         assert res is None
-        assert (prn.info.call_count == 1 and prn.error.call_count == 1 and 
+        assert (prn.info.call_count == 1 and prn.error.call_count == 1 and
                 mock.call('Failed to submit CSR...') in prn.error.mock_calls)
 
 

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -121,11 +121,11 @@ def test_can_read_cert_stat_cert(tmpdir):
     agent.CERT_PATH = str(tmpdir)
     agent.CLIENT_CERT_PATH = str(crt)
     agent.CLIENT_KEY_PATH = str(key)
-    with mock.patch('builtins.print') as prn:
+    with mock.patch('agent.logger') as prn:
         # Path(crt).touch(mode=0o100)
         with pytest.raises(SystemExit):
             agent.can_read_cert()
-        assert mock.call('Permission denied when trying to read the certificate file.') in prn.mock_calls
+        assert mock.call('Permission denied when trying to read the certificate file.') in prn.error.mock_calls
 
 
 def test_can_read_cert_stat_key(tmpdir):
@@ -134,12 +134,12 @@ def test_can_read_cert_stat_key(tmpdir):
     agent.CERT_PATH = str(tmpdir)
     agent.CLIENT_CERT_PATH = str(crt)
     agent.CLIENT_KEY_PATH = str(key)
-    with mock.patch('builtins.print') as prn:
+    with mock.patch('agent.logger') as prn:
         Path(agent.CLIENT_CERT_PATH).touch(mode=0o600)
         # Path(agent.CLIENT_KEY_PATH).touch(mode=0o100)
         with pytest.raises(SystemExit):
             agent.can_read_cert()
-        assert mock.call('Permission denied when trying to read the key file.') in prn.mock_calls
+        assert mock.call('Permission denied when trying to read the key file.') in prn.error.mock_calls
 
 
 def test_can_read_cert_none_on_success(tmpdir):
@@ -148,7 +148,7 @@ def test_can_read_cert_none_on_success(tmpdir):
     agent.CERT_PATH = str(tmpdir)
     agent.CLIENT_CERT_PATH = str(crt)
     agent.CLIENT_KEY_PATH = str(key)
-    with mock.patch('builtins.print'):
+    with mock.patch('agent.logger'):
         Path(agent.CLIENT_CERT_PATH).touch(mode=0o600)
         Path(agent.CLIENT_KEY_PATH).touch(mode=0o600)
         can_read = agent.can_read_cert()
@@ -235,12 +235,12 @@ def test_get_ca_cert():
 
 def test_get_ca_cert_none_on_fail():
     with mock.patch('requests.get') as req, \
-            mock.patch('builtins.print') as prn:
+            mock.patch('agent.logger') as prn:
         req.return_value.ok = False
         ca_bundle = agent.get_ca_cert()
     assert ca_bundle is None
-    assert mock.call('Failed to get CA...') in prn.mock_calls
-    assert prn.call_count == 3
+    assert mock.call('Failed to get CA...') in prn.error.mock_calls
+    assert prn.error.call_count == 3
 
 
 def test_get_open_ports(net_connections_fixture, netstat_result):
@@ -306,11 +306,12 @@ def test_renew_cert(raspberry_cpuinfo, tmpdir, cert, key):
             create=True
     ), \
     mock.patch('socket.getfqdn') as getfqdn, \
-    mock.patch('builtins.print') as prn:  # noqa E213
+    mock.patch('agent.logger') as prn:  # noqa E213
         getfqdn.return_value = 'localhost'
         res = agent.renew_expired_cert(None, None)
         assert res is None
-        assert (prn.call_count == 2 and mock.call('Failed to submit CSR...') in prn.mock_calls)
+        assert (prn.info.call_count == 1 and prn.error.call_count == 1
+                and mock.call('Failed to submit CSR...') in prn.error.mock_calls)
 
 
 @pytest.mark.vcr
@@ -322,10 +323,10 @@ def test_say_hello_failed(tmpdir, invalid_cert, invalid_key):
     agent.CLIENT_KEY_PATH = str(key_path)
     Path(agent.CLIENT_CERT_PATH).write_text(invalid_cert)
     Path(agent.CLIENT_KEY_PATH).write_text(invalid_key)
-    with mock.patch('builtins.print') as prn:
+    with mock.patch('agent.logger') as prn:
         with pytest.raises(json.decoder.JSONDecodeError):
             _ = agent.say_hello()
-        assert mock.call('Hello failed.') in prn.mock_calls
+        assert mock.call('Hello failed.') in prn.error.mock_calls
 
 
 @pytest.mark.vcr
@@ -446,17 +447,16 @@ def test_fetch_credentials(tmpdir):
         ]
     )
     mock_resp.return_value.ok = True
-    with mock.patch('builtins.print'), \
+    with mock.patch('agent.logger'), \
             mock.patch('agent.can_read_cert') as cr, \
             mock.patch('requests.request') as req, \
-            mock.patch('builtins.print'), \
             mock.patch('os.chmod') as chm, \
             mock.patch('os.chown') as chw:
 
         cr.return_value = True
         req.return_value = mock_resp
         mock_resp.return_value.ok = True
-        agent.fetch_credentials(False, False)
+        agent.fetch_credentials(False)
 
         assert Path.exists(tmpdir / user / 'name1.json')
         assert Path.exists(tmpdir / user / 'name2.json')
@@ -503,15 +503,14 @@ def test_fetch_credentials_no_dir(tmpdir):
         ]
     )
     mock_resp.return_value.ok = True
-    with mock.patch('builtins.print'), \
+    with mock.patch('agent.logger'), \
             mock.patch('agent.can_read_cert') as cr, \
-            mock.patch('requests.request') as req, \
-            mock.patch('builtins.print'):
+            mock.patch('requests.request') as req:
 
         cr.return_value = True
         req.return_value = mock_resp
         mock_resp.return_value.ok = True
-        agent.fetch_credentials(False, False)
+        agent.fetch_credentials(False)
 
         assert Path.exists(file_path1)
         assert Path.exists(file_path2)


### PR DESCRIPTION
closes #176 

By default used `INFO` log level
If there is a `logging,ini` file (can be changed by env) then use it as log config
If there is `log_level=LEVEL` in `config.ini` it applies to logging configurtion as preffered

There are different log configuration for manual start mode and daemon start mode:
- If no config file used, In daemon mode  to log format the thread name adds.
- If used config file, then for daemon and manual modes could be used different config files.
There are two log config path variables LOG_CFG_PATH and DAEMON_LOG_CFG_PATH, by default both is `/opt/wott/logging.ini`. But both could be changed by environment variables LOG_CFG_PATH and DAEMON_LOG_CFG_PATH relatively.

