### PR TITLE
201 Debian Buster support.

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -1,5 +1,6 @@
 #DEBHELPER#
 
+ldconfig
 CLAIM_RESULT=$(wott-agent claim-url)
 EXIT_CODE=$?
 CLAIM_URL=$(printf "${CLAIM_RESULT}" | tail -n1)


### PR DESCRIPTION
Run ldconfig before using agent to make sure `iptables` libraries are available for use.
Closes #201 