### PR TITLE
Fix Snap operation

### DIFF
--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -381,7 +381,6 @@ def send_ping(dev=False):
         return
 
     ping = ping.json()
-    packages = get_deb_packages()
     connections, ports = security_helper.netstat_scan()
     payload = {
         'device_operating_system_version': platform.release(),
@@ -392,8 +391,10 @@ def send_ping(dev=False):
         'confinement': CONFINEMENT.name,
         'installation': detect_installation().name
     }
-    if ping.get('deb_packages_hash') != packages['hash']:
-        payload['deb_packages'] = packages
+    if CONFINEMENT != Confinement.SNAP:
+        packages = get_deb_packages()
+        if ping.get('deb_packages_hash') != packages['hash']:
+            payload['deb_packages'] = packages
 
     # Things we can't do within a Snap or Docker
     if CONFINEMENT not in (Confinement.SNAP, Confinement.DOCKER, Confinement.BALENA):

--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -383,7 +383,6 @@ def send_ping(dev=False):
         return
 
     ping = ping.json()
-    connections, ports = security_helper.netstat_scan()
     payload = {
         'device_operating_system_version': platform.release(),
         'fqdn': socket.getfqdn(),
@@ -400,18 +399,14 @@ def send_ping(dev=False):
 
     # Things we can't do within a Snap or Docker
     if CONFINEMENT not in (Confinement.SNAP, Confinement.DOCKER, Confinement.BALENA):
-        payload.update({
-            'processes': security_helper.process_scan(),
-            'logins': journal_helper.logins_last_hour(),
-            'default_password': security_helper.check_for_default_passwords(CONFIG_PATH)
-        })
-
-    # Things we cannot do in Docker
-    if CONFINEMENT not in (Confinement.DOCKER, Confinement.BALENA):
+        connections, ports = security_helper.netstat_scan()
         blocklist = ping
         iptables_helper.block(blocklist)
 
         payload.update({
+            'processes': security_helper.process_scan(),
+            'logins': journal_helper.logins_last_hour(),
+            'default_password': security_helper.check_for_default_passwords(CONFIG_PATH),
             'selinux_status': security_helper.selinux_status(),
             'app_armor_enabled': security_helper.is_app_armor_enabled(),
             'firewall_rules': iptables_helper.dump(),

--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -51,6 +51,8 @@ MTLS_DEV_PORT = 8002
 CONFINEMENT = detect_confinement()
 
 CONFIG_PATH = os.getenv('CONFIG_PATH', '/opt/wott')
+if CONFINEMENT == Confinement.SNAP:
+    Locker.LOCKDIR = CONFIG_PATH
 CERT_PATH = os.getenv('CERT_PATH', os.path.join(CONFIG_PATH, 'certs'))
 CREDENTIALS_PATH = os.getenv('CREDENTIALS_PATH', os.path.join(CONFIG_PATH, 'credentials'))
 

--- a/agent/rpi_helper.py
+++ b/agent/rpi_helper.py
@@ -3,8 +3,6 @@ import os
 from enum import Enum
 import pkg_resources
 
-import apt
-
 import agent
 
 
@@ -59,6 +57,7 @@ def detect_confinement():
 
 def detect_installation():
     try:
+        import apt
         cache = apt.Cache()
         if __file__ in cache['wott-agent'].installed_files:
             return Installation.DEB
@@ -69,6 +68,7 @@ def detect_installation():
 
 
 def get_deb_packages():
+    import apt
     cache = apt.Cache()
     packages = [deb for deb in cache if deb.is_installed]
     packages_str = str(sorted((deb.installed.package.name, deb.installed.version) for deb in packages))


### PR DESCRIPTION
Put locks in CONFIG_PATH.
Don't read apt database, passwords and selinux/apparmor status.
Closes #221 
Closes #220 
Relates to wottsecurity/agent-snap#9